### PR TITLE
Fix - Change Global Vars to Script (Module Scope) Vars

### DIFF
--- a/Functions/Add-PRTGObjectTAG.ps1
+++ b/Functions/Add-PRTGObjectTAG.ps1
@@ -48,22 +48,22 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
 
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree,
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree,
 
         # skip errors if an tag is not present
         [Parameter(Mandatory=$false)]

--- a/Functions/Compare-PRTGDeviceSensorsFromTemplateTAG.ps1
+++ b/Functions/Compare-PRTGDeviceSensorsFromTemplateTAG.ps1
@@ -57,7 +57,7 @@
         # SensorTree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Connect-PRTGServer.ps1
+++ b/Functions/Connect-PRTGServer.ps1
@@ -4,8 +4,8 @@
        Connect-PRTGServer
 
     .DESCRIPTION
-       Connect to PRTG Server, creates global variables with connection data and the current sensor tree from PRTG Core Server.
-       The global variables are used as default parameters in other PRTG-module cmdlets to interact with PRTG.
+       Connect to PRTG Server, creates module-scope variables with connection data and the current sensor tree from PRTG Core Server.
+       The module-scope variables are used as default parameters in other PRTG-module cmdlets to interact with PRTG.
        
        Connect-PRTGServer needs to be run at first when starting to work.
     
@@ -13,10 +13,10 @@
        Author: Andreas Bellstedt
 
        Created global Variables by the cmdlet:
-            $global:PRTGServer
-            $global:PRTGUser
-            $global:PRTGPass
-            $global:PRTGSensorTree (created through cmdlet Invoke-PRTGSensorTreeRefresh)
+            $SCRIPT:PRTGServer
+            $SCRIPT:PRTGUser
+            $SCRIPT:PRTGPass
+            $SCRIPT:PRTGSensorTree (created through cmdlet Invoke-PRTGSensorTreeRefresh)
 
     .LINK
        https://github.com/AndiBellstedt/PoShPRTG
@@ -43,6 +43,7 @@
                    SupportsShouldProcess=$false, 
                    ConfirmImpact='Low')]
     [OutputType([XML])]
+
     Param(
         # Url for PRTG Server
         [Parameter(Mandatory=$true,
@@ -102,6 +103,7 @@
             Write-Log -LogText "No credential specified! Credential is needed..." -LogType Warning -LogScope $Local:logscope -Warning -NoFileStatus
             $Credential = Get-Credential -Message "Please specify logon cedentials for PRTG" -UserName $User
         }
+        #If a user entered domain credentials, strip off the domain
         if(($credential.UserName.Split('\')).count -gt 1) { 
             $User = $credential.UserName.Split('\')[1] 
         } else { 
@@ -124,12 +126,12 @@
         Remove-Variable pass -Force -ErrorAction Ignore -Verbose:$false -Debug:$false -WhatIf:$false
     }    
 
-    $global:PRTGServer = $Prefix + $server
-    $global:PRTGUser = $User
-    $global:PRTGPass = $Hash
+    $SCRIPT:PRTGServer = $Prefix + $server
+    $SCRIPT:PRTGUser = $User
+    $SCRIPT:PRTGPass = $Hash
     
-    Write-Log -LogText "Connection to PRTG ($($global:PRTGServer)) as user $($global:PRTGUser)" -LogType Info -LogScope $Local:logscope -NoFileStatus -Console
-    Invoke-PRTGSensorTreeRefresh -Server $global:PRTGServer -User $global:PRTGUser -Pass $global:PRTGPass -Verbose:$false
+    Write-Log -LogText "Connection to PRTG ($PRTGServer) as user $PRTGUser" -LogType Info -LogScope $Local:logscope -NoFileStatus -Console
+    Invoke-PRTGSensorTreeRefresh -Server $PRTGServer -User $PRTGUser -Pass $PRTGPass -Verbose:$false
     if($PassThru) {
         $Result = New-Object -TypeName psobject -Property @{
             Server = $Prefix + $server

--- a/Functions/Copy-PRTGObject.ps1
+++ b/Functions/Copy-PRTGObject.ps1
@@ -51,22 +51,22 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
 
         # Sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
 
     $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Disable-PRTGObject.ps1
+++ b/Functions/Disable-PRTGObject.ps1
@@ -57,22 +57,22 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
         
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Disconnect-PRTGServer.ps1
+++ b/Functions/Disconnect-PRTGServer.ps1
@@ -6,9 +6,9 @@
     .DESCRIPTION
        Clears globale variables from memory
        Globale Variablen: 
-            $global:PRTGServer
-            $global:PRTGUser
-            $global:PRTGPass
+            $SCRIPT:PRTGServer
+            $SCRIPT:PRTGUser
+            $SCRIPT:PRTGPass
 
     .NOTES
        Author: Andreas Bellstedt

--- a/Functions/Enable-PRTGObject.ps1
+++ b/Functions/Enable-PRTGObject.ps1
@@ -47,22 +47,22 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
         
         # Sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name    

--- a/Functions/Find-PRTGObject.ps1
+++ b/Functions/Find-PRTGObject.ps1
@@ -56,7 +56,7 @@
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree 
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree 
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Get-PRTGDevice.ps1
+++ b/Functions/Get-PRTGDevice.ps1
@@ -67,7 +67,7 @@
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree 
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree 
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Get-PRTGGroup.ps1
+++ b/Functions/Get-PRTGGroup.ps1
@@ -65,7 +65,7 @@
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree 
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree 
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Get-PRTGObject.ps1
+++ b/Functions/Get-PRTGObject.ps1
@@ -114,7 +114,7 @@
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Get-PRTGObjectProperty.ps1
+++ b/Functions/Get-PRTGObjectProperty.ps1
@@ -45,7 +45,7 @@
         # SensorTree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Get-PRTGObjectTAG.ps1
+++ b/Functions/Get-PRTGObjectTAG.ps1
@@ -34,7 +34,7 @@
         # SensorTree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     $Local:logscope = $MyInvocation.MyCommand.Name
         

--- a/Functions/Get-PRTGProbe.ps1
+++ b/Functions/Get-PRTGProbe.ps1
@@ -66,7 +66,7 @@
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree 
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree 
 
     )
     Begin {

--- a/Functions/Get-PRTGSensor.ps1
+++ b/Functions/Get-PRTGSensor.ps1
@@ -66,7 +66,7 @@
         # Sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree 
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree 
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Get-PRTGSensorTree.ps1
+++ b/Functions/Get-PRTGSensorTree.ps1
@@ -28,19 +28,19 @@
                    Position=0)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer, 
+            [String]$Server = $SCRIPT:PRTGServer, 
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false,
                    Position=1)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false,
                    Position=2)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass
+            [String]$Pass = $SCRIPT:PRTGPass
     )
     $Local:logscope = $MyInvocation.MyCommand.Name
     $body =  @{

--- a/Functions/Invoke-PRTGObjectRefresh.ps1
+++ b/Functions/Invoke-PRTGObjectRefresh.ps1
@@ -34,17 +34,17 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass
+            [String]$Pass = $SCRIPT:PRTGPass
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name    

--- a/Functions/Invoke-PRTGSensorTreeRefresh.ps1
+++ b/Functions/Invoke-PRTGSensorTreeRefresh.ps1
@@ -28,19 +28,19 @@
                    Position=0)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer, 
+            [String]$Server = $SCRIPT:PRTGServer, 
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false,
                    Position=1)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false,
                    Position=2)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
 
         [Parameter(Mandatory=$false)]
             [Switch]$PassThru
@@ -49,7 +49,7 @@
 
     Write-Log -LogText "Refresh PRTG SensorTree in Memory" -LogType Query -LogScope $Local:logscope -NoFileStatus -DebugOutput
     $Result = Get-PRTGSensorTree -Server $Server -User $User -Pass $Pass -Verbose:$false
-    $global:PRTGSensorTree = $Result
+    $SCRIPT:PRTGSensorTree = $Result
 
     if($PassThru) { return $Result }
 }

--- a/Functions/Move-PRTGObjectPosition.ps1
+++ b/Functions/Move-PRTGObjectPosition.ps1
@@ -42,22 +42,22 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
         
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name    

--- a/Functions/New-PRTGDefaultFolderStructureToProbe.ps1
+++ b/Functions/New-PRTGDefaultFolderStructureToProbe.ps1
@@ -28,33 +28,33 @@
         #ID of the group that contains the structure to be copied to the destination probe
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [int]$TemplateFolderStructureID = (Get-PRTGObject -Name "Groups for new customer" -Type group -SensorTree $global:PRTGSensorTree -Verbose:$false | Select-Object -ExpandProperty ObjID),
+            [int]$TemplateFolderStructureID = (Get-PRTGObject -Name "Groups for new customer" -Type group -SensorTree $SCRIPT:PRTGSensorTree -Verbose:$false | Select-Object -ExpandProperty ObjID),
         
         #ID of the destination probe
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [int]$ProbeID = (Get-PRTGProbe -SensorTree $global:PRTGSensorTree -Verbose:$false | Sort-Object fullname | Select-Object Name, objID | Out-GridView -Title "Please select destination probe" -OutputMode Single | Select-Object -ExpandProperty ObjID),
+            [int]$ProbeID = (Get-PRTGProbe -SensorTree $SCRIPT:PRTGSensorTree -Verbose:$false | Sort-Object fullname | Select-Object Name, objID | Out-GridView -Title "Please select destination probe" -OutputMode Single | Select-Object -ExpandProperty ObjID),
 
         # Url for PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
 
         # SensorTree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     $logscope = $MyInvocation.MyCommand.Name
     

--- a/Functions/New-PRTGDeviceFromTemplate.ps1
+++ b/Functions/New-PRTGDeviceFromTemplate.ps1
@@ -34,38 +34,38 @@
 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [int]$TemplateSystem = (Get-PRTGObject -Name "Basic operatingsystem" -Recursive -Type device -SensorTree $global:PRTGSensorTree | Sort-Object Fullname | Select-Object fullname, objID | Out-GridView -Title "Please specify operatingsystem for new system" -OutputMode Single | Select-Object -ExpandProperty ObjID),
+            [int]$TemplateSystem = (Get-PRTGObject -Name "Basic operatingsystem" -Recursive -Type device -SensorTree $SCRIPT:PRTGSensorTree | Sort-Object Fullname | Select-Object fullname, objID | Out-GridView -Title "Please specify operatingsystem for new system" -OutputMode Single | Select-Object -ExpandProperty ObjID),
 
         [Parameter(Mandatory=$false)]
-            [int[]]$TemplateRole = (Get-PRTGObject -Name "Specific roles" -Recursive -Type device -SensorTree $global:PRTGSensorTree | Sort-Object Fullname | Select-Object FullName, objID | Out-GridView -Title "Please select roles for new system" -OutputMode Multiple | Select-Object -ExpandProperty ObjID),
+            [int[]]$TemplateRole = (Get-PRTGObject -Name "Specific roles" -Recursive -Type device -SensorTree $SCRIPT:PRTGSensorTree | Sort-Object Fullname | Select-Object FullName, objID | Out-GridView -Title "Please select roles for new system" -OutputMode Multiple | Select-Object -ExpandProperty ObjID),
 
         [Parameter(Mandatory=$false)]
             [string[]]$TemplateSensorFilter = "MUSS MANUELL*",
             
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [int]$Destination = (Get-PRTGObject -Type group -SensorTree $global:PRTGSensorTree | Sort-Object Fullname | Select-Object FullName, objID | Out-GridView -Title "Please select destination for new system" -OutputMode Single  | Select-Object -ExpandProperty ObjID),
+            [int]$Destination = (Get-PRTGObject -Type group -SensorTree $SCRIPT:PRTGSensorTree | Sort-Object Fullname | Select-Object FullName, objID | Out-GridView -Title "Please select destination for new system" -OutputMode Single  | Select-Object -ExpandProperty ObjID),
 
         # Url for PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
 
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     $Local:logscope = $MyInvocation.MyCommand.Name
     [array]$CopyObjectCollection = @()

--- a/Functions/Receive-PRTGObject.ps1
+++ b/Functions/Receive-PRTGObject.ps1
@@ -51,17 +51,17 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass
+            [String]$Pass = $SCRIPT:PRTGPass
     )
     $Local:logscope = $MyInvocation.MyCommand.Name
     $SortDirectionPRTGStyle = if($SortDirection -eq "Desc"){"-"}else{''}

--- a/Functions/Receive-PRTGObjectDetail.ps1
+++ b/Functions/Receive-PRTGObjectDetail.ps1
@@ -45,17 +45,17 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass
+            [String]$Pass = $SCRIPT:PRTGPass
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Receive-PRTGObjectProperty.ps1
+++ b/Functions/Receive-PRTGObjectProperty.ps1
@@ -50,17 +50,17 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass
+            [String]$Pass = $SCRIPT:PRTGPass
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Receive-PRTGObjectStatus.ps1
+++ b/Functions/Receive-PRTGObjectStatus.ps1
@@ -43,17 +43,17 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass
+            [String]$Pass = $SCRIPT:PRTGPass
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Remove-PRTGObject.ps1
+++ b/Functions/Remove-PRTGObject.ps1
@@ -49,22 +49,22 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
 
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree,
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree,
 
         # returns the deleted object 
         [Parameter(Mandatory=$false)]

--- a/Functions/Remove-PRTGObjectTAG.ps1
+++ b/Functions/Remove-PRTGObjectTAG.ps1
@@ -42,22 +42,22 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
 
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree,
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree,
 
         # skip errors if an tag is not present
         [Parameter(Mandatory=$false)]

--- a/Functions/Rename-PRTGObject.ps1
+++ b/Functions/Rename-PRTGObject.ps1
@@ -41,22 +41,22 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
         
         # SensorTree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     $Local:logscope = $MyInvocation.MyCommand.Name
     $body =  @{

--- a/Functions/Set-PRTGObjectAlamAcknowledgement.ps1
+++ b/Functions/Set-PRTGObjectAlamAcknowledgement.ps1
@@ -44,17 +44,17 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass
+            [String]$Pass = $SCRIPT:PRTGPass
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name    

--- a/Functions/Set-PRTGObjectPriority.ps1
+++ b/Functions/Set-PRTGObjectPriority.ps1
@@ -50,22 +50,22 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
         
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/Functions/Set-PRTGObjectProperty.ps1
+++ b/Functions/Set-PRTGObjectProperty.ps1
@@ -54,22 +54,22 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass,
+            [String]$Pass = $SCRIPT:PRTGPass,
         
         # sensortree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name    

--- a/Functions/Show-PRTGTemplateSummaryFromObjectTAG.ps1
+++ b/Functions/Show-PRTGTemplateSummaryFromObjectTAG.ps1
@@ -53,7 +53,7 @@
         # SensorTree from PRTG Server 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [xml]$SensorTree = $global:PRTGSensorTree
+            [xml]$SensorTree = $SCRIPT:PRTGSensorTree
     )
     $Local:logscope = $MyInvocation.MyCommand.Name
 

--- a/Functions/Test-PRTGObjectNotification.ps1
+++ b/Functions/Test-PRTGObjectNotification.ps1
@@ -36,17 +36,17 @@
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-            [String]$Server = $global:PRTGServer,
+            [String]$Server = $SCRIPT:PRTGServer,
 
         # User for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$User = $global:PRTGUser,
+            [String]$User = $SCRIPT:PRTGUser,
 
         # Password or PassHash for PRTG Authentication
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
-            [String]$Pass = $global:PRTGPass
+            [String]$Pass = $SCRIPT:PRTGPass
     )
     Begin {
         $Local:logscope = $MyInvocation.MyCommand.Name

--- a/PoShPRTG.psm1
+++ b/PoShPRTG.psm1
@@ -115,23 +115,23 @@
 #        # SensorTree from PRTG Server 
 #        [Parameter(Mandatory=$false)]
 #        [ValidateNotNullOrEmpty()]
-#            [xml]$SensorTree = $global:PRTGSensorTree,
+#            [xml]$SensorTree = $SCRIPT:PRTGSensorTree,
 #
 #        # Url for PRTG Server 
 #        [Parameter(Mandatory=$false)]
 #        [ValidateNotNullOrEmpty()]
 #        [ValidateScript({if( ($_.StartsWith("http")) ){$true}else{$false}})]
-#            [String]$Server = $global:PRTGServer,
+#            [String]$Server = $SCRIPT:PRTGServer,
 #
 #        # User for PRTG Authentication
 #        [Parameter(Mandatory=$false)]
 #        [ValidateNotNullOrEmpty()]
-#            [String]$User = $global:PRTGUser,
+#            [String]$User = $SCRIPT:PRTGUser,
 #
 #        # Password or PassHash for PRTG Authentication
 #        [Parameter(Mandatory=$false)]
 #        [ValidateNotNullOrEmpty()]
-#            [String]$Pass = $global:PRTGPass
+#            [String]$Pass = $SCRIPT:PRTGPass
 #    )
 #    Begin {
 #        $Local:logscope = $MyInvocation.MyCommand.Name


### PR DESCRIPTION
$SCRIPT in module scope persists variables for the life of the loaded module, which is normally effectively the life of the powershell session.

Global Variables expose this private information to the session unnecessarily. This fix resolves that.