### PR TITLE
Release PoShPRTG v1.5.1.1

### DIFF
--- a/PoShPRTG/PoShPRTG.psd1
+++ b/PoShPRTG/PoShPRTG.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     # Script module or binary module file associated with this manifest
-    ModuleToProcess       = 'PoShPRTG.psm1'
+    RootModule            = 'PoShPRTG.psm1'
 
     # Version number of this module.
     ModuleVersion         = '1.5.1.1'
@@ -117,7 +117,19 @@
         PSData = @{
 
             # Tags applied to this module. These help with module discovery in online galleries.
-            Tags         = @('PoShPRTG', 'PSPRTG', 'PRTG', 'PRTGNetworkMonitor', 'PRTG_Network_Monitor', 'PowerShell', 'Automation', 'Management', 'Monitoring')
+            Tags         = @(
+                'PoShPRTG',
+                'PSPRTG',
+                'PRTG',
+                'PRTGNetworkMonitor',
+                'PRTG_Network_Monitor',
+                'PowerShell',
+                'Automation',
+                'Management',
+                'Monitoring',
+                'PSEdition_Desktop',
+                'Windows'
+            )
 
             # A URL to the license for this module.
             LicenseUri   = 'https://github.com/AndiBellstedt/PoShPRTG/blob/master/license'

--- a/PoShPRTG/PoShPRTG.psd1
+++ b/PoShPRTG/PoShPRTG.psd1
@@ -3,7 +3,7 @@
     ModuleToProcess       = 'PoShPRTG.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '1.5.1.0'
+    ModuleVersion         = '1.5.1.1'
 
     # ID used to uniquely identify this module
     GUID                  = '2dd57587-dbe7-4f17-a5fb-3c9d9999af76'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-![logo][]
 
-PowerShell for PRTG - PoShPRTG
-====================
+# ![logo][] PowerShell for PRTG - PoShPRTG
+| Plattform | Information |
+|- |-|-|
+| PowerShell gallery | [![PowerShell Gallery](https://img.shields.io/powershellgallery/v/PoShPRTG?label=psgallery)](https://www.powershellgallery.com/packages/PoShPRTG) [![PowerShell Gallery](https://img.shields.io/powershellgallery/p/PoShPRTG)](https://www.powershellgallery.com/packages/PoShPRTG) [![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/PoShPRTG?style=plastic)](https://www.powershellgallery.com/packages/PoShPRTG) |
+| GitHub  | [![GitHub release](https://img.shields.io/github/release/AndiBellstedt/PoShPRTG.svg)](https://github.com/AndiBellstedt/PoShPRTG/releases/latest) ![GitHub](https://img.shields.io/github/license/AndiBellstedt/PoShPRTG?style=plastic) <br> ![GitHub issues](https://img.shields.io/github/issues-raw/AndiBellstedt/PoShPRTG?style=plastic) <br> ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/AndiBellstedt/PoShPRTG/master?label=last%20commit%3A%20master&style=plastic) <br> ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/AndiBellstedt/PoShPRTG/development?label=last%20commit%3A%20development&style=plastic) |
+<br>
+
+# Description
 
 Welcome to the developing repository for PoShPRTG module.
 PoShPRTG is a comprehensive module for administering PRTG NETWORK MONITOR (www.paessler.com/prtg).
@@ -10,7 +15,7 @@ It eases the rollout-/deployment process for new machines and managment of exist
 The shipped cmdlets are used to call the PRTG API (http://prtg.paessler.com/api.htm?username=demo&password=demodemo)
 
 
-All cmdlets are build with 
+All cmdlets are build with
 - powershell regular verbs
 - mostly with pipeling availabilties
 - comprehensive logging on verbose and debug channel
@@ -18,8 +23,8 @@ All cmdlets are build with
 
 The idea for the module was born while maintaining quiete a large deployment of PRTG installation in my job at abtis GmbH (www.abtis.de)
 
-I startet to dig into the API documentation and write some powershell functions after work, just for fun and hopefully easy of work. 
-After then the collection of functions was growing and growing so I decided to put them together in this module. 
+I startet to dig into the API documentation and write some powershell functions after work, just for fun and hopefully easy of work.
+After then the collection of functions was growing and growing so I decided to put them together in this module.
 
 
 Hopefully some other people may benefit from my work and investigation.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # ![logo][] PowerShell for PRTG - PoShPRTG
 | Plattform | Information |
-|- |-|-|
+| --------- | ----------- |
 | PowerShell gallery | [![PowerShell Gallery](https://img.shields.io/powershellgallery/v/PoShPRTG?label=psgallery)](https://www.powershellgallery.com/packages/PoShPRTG) [![PowerShell Gallery](https://img.shields.io/powershellgallery/p/PoShPRTG)](https://www.powershellgallery.com/packages/PoShPRTG) [![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/PoShPRTG?style=plastic)](https://www.powershellgallery.com/packages/PoShPRTG) |
 | GitHub  | [![GitHub release](https://img.shields.io/github/release/AndiBellstedt/PoShPRTG.svg)](https://github.com/AndiBellstedt/PoShPRTG/releases/latest) ![GitHub](https://img.shields.io/github/license/AndiBellstedt/PoShPRTG?style=plastic) <br> ![GitHub issues](https://img.shields.io/github/issues-raw/AndiBellstedt/PoShPRTG?style=plastic) <br> ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/AndiBellstedt/PoShPRTG/master?label=last%20commit%3A%20master&style=plastic) <br> ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/AndiBellstedt/PoShPRTG/development?label=last%20commit%3A%20development&style=plastic) |
 <br>

--- a/install.ps1
+++ b/install.ps1
@@ -45,7 +45,7 @@ Param (
 $ModuleName = "PoShPRTG"
 
 # Base path to the github repository
-$BaseUrl = "https://github.com/<InsertUsernameHere>/PoShPRTG"
+$BaseUrl = "https://github.com/AndiBellstedt/PoShPRTG"
 
 # If the module is in a subfolder of the cloned repository, specify relative path here. Empty string to skip.
 $SubFolder = "PoShPRTG"
@@ -61,8 +61,7 @@ if ($install_Branch) { $Branch = $install_Branch }
 #endregion Parameter Calculation
 
 #region Utility Functions
-function Compress-Archive
-{
+function Compress-Archive {
     <#
         .SYNOPSIS
             Creates an archive, or zipped file, from specified files and folders.
@@ -149,17 +148,17 @@ function Compress-Archive
         $LiteralPath,
 
         [parameter (mandatory = $true,
-                    Position = 1,
-                    ValueFromPipeline = $false,
-                    ValueFromPipelineByPropertyName = $false)]
+            Position = 1,
+            ValueFromPipeline = $false,
+            ValueFromPipelineByPropertyName = $false)]
         [ValidateNotNullOrEmpty()]
         [string]
         $DestinationPath,
 
         [parameter (
-                    mandatory = $false,
-                    ValueFromPipeline = $false,
-                    ValueFromPipelineByPropertyName = $false)]
+            mandatory = $false,
+            ValueFromPipeline = $false,
+            ValueFromPipelineByPropertyName = $false)]
         [ValidateSet("Optimal", "NoCompression", "Fastest")]
         [string]
         $CompressionLevel = "Optimal",
@@ -175,8 +174,7 @@ function Compress-Archive
         $Force = $false
     )
 
-    BEGIN
-    {
+    BEGIN {
         Add-Type -AssemblyName System.IO.Compression -ErrorAction Ignore
         Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Ignore
 
@@ -205,8 +203,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 '@
 
         #region Utility Functions
-        function GetResolvedPathHelper
-        {
+        function GetResolvedPathHelper {
             param
             (
                 [string[]]
@@ -222,29 +219,21 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $resolvedPaths = @()
 
             # null and empty check are are already done on Path parameter at the cmdlet layer.
-            foreach ($currentPath in $path)
-            {
-                try
-                {
-                    if ($isLiteralPath)
-                    {
+            foreach ($currentPath in $path) {
+                try {
+                    if ($isLiteralPath) {
                         $currentResolvedPaths = Resolve-Path -LiteralPath $currentPath -ErrorAction Stop
-                    }
-                    else
-                    {
+                    } else {
                         $currentResolvedPaths = Resolve-Path -Path $currentPath -ErrorAction Stop
                     }
-                }
-                catch
-                {
+                } catch {
                     $errorMessage = ($LocalizedData.PathNotFoundError -f $currentPath)
                     $exception = New-Object System.InvalidOperationException $errorMessage, $_.Exception
                     $errorRecord = CreateErrorRecordHelper "ArchiveCmdletPathNotFound" $null ([System.Management.Automation.ErrorCategory]::InvalidArgument) $exception $currentPath
                     $callerPSCmdlet.ThrowTerminatingError($errorRecord)
                 }
 
-                foreach ($currentResolvedPath in $currentResolvedPaths)
-                {
+                foreach ($currentResolvedPath in $currentResolvedPaths) {
                     $resolvedPaths += $currentResolvedPath.ProviderPath
                 }
             }
@@ -252,18 +241,15 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $resolvedPaths
         }
 
-        function Add-CompressionAssemblies
-        {
+        function Add-CompressionAssemblies {
 
-            if ($PSEdition -eq "Desktop")
-            {
+            if ($PSEdition -eq "Desktop") {
                 Add-Type -AssemblyName System.IO.Compression
                 Add-Type -AssemblyName System.IO.Compression.FileSystem
             }
         }
 
-        function IsValidFileSystemPath
-        {
+        function IsValidFileSystemPath {
             param
             (
                 [string[]]
@@ -273,10 +259,8 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $result = $true;
 
             # null and empty check are are already done on Path parameter at the cmdlet layer.
-            foreach ($currentPath in $path)
-            {
-                if (!([System.IO.File]::Exists($currentPath) -or [System.IO.Directory]::Exists($currentPath)))
-                {
+            foreach ($currentPath in $path) {
+                if (!([System.IO.File]::Exists($currentPath) -or [System.IO.Directory]::Exists($currentPath))) {
                     $errorMessage = ($LocalizedData.PathNotFoundError -f $currentPath)
                     ThrowTerminatingErrorHelper "PathNotFound" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $currentPath
                 }
@@ -286,8 +270,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
         }
 
 
-        function ValidateDuplicateFileSystemPath
-        {
+        function ValidateDuplicateFileSystemPath {
             param
             (
                 [string]
@@ -300,23 +283,18 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $uniqueInputPaths = @()
 
             # null and empty check are are already done on Path parameter at the cmdlet layer.
-            foreach ($currentPath in $path)
-            {
+            foreach ($currentPath in $path) {
                 $currentInputPath = $currentPath.ToUpper()
-                if ($uniqueInputPaths.Contains($currentInputPath))
-                {
+                if ($uniqueInputPaths.Contains($currentInputPath)) {
                     $errorMessage = ($LocalizedData.DuplicatePathFoundError -f $inputParameter, $currentPath, $inputParameter)
                     ThrowTerminatingErrorHelper "DuplicatePathFound" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $currentPath
-                }
-                else
-                {
+                } else {
                     $uniqueInputPaths += $currentInputPath
                 }
             }
         }
 
-        function CompressionLevelMapper
-        {
+        function CompressionLevelMapper {
             param
             (
                 [string]
@@ -326,14 +304,11 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $compressionLevelFormat = [System.IO.Compression.CompressionLevel]::Optimal
 
             # CompressionLevel format is already validated at the cmdlet layer.
-            switch ($compressionLevel.ToString())
-            {
-                "Fastest"
-                {
+            switch ($compressionLevel.ToString()) {
+                "Fastest" {
                     $compressionLevelFormat = [System.IO.Compression.CompressionLevel]::Fastest
                 }
-                "NoCompression"
-                {
+                "NoCompression" {
                     $compressionLevelFormat = [System.IO.Compression.CompressionLevel]::NoCompression
                 }
             }
@@ -341,8 +316,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             return $compressionLevelFormat
         }
 
-        function CompressArchiveHelper
-        {
+        function CompressArchiveHelper {
             param
             (
                 [string[]]
@@ -362,26 +336,20 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $sourceFilePaths = @()
             $sourceDirPaths = @()
 
-            foreach ($currentPath in $sourcePath)
-            {
+            foreach ($currentPath in $sourcePath) {
                 $result = Test-Path -LiteralPath $currentPath -PathType Leaf
-                if ($result -eq $true)
-                {
+                if ($result -eq $true) {
                     $sourceFilePaths += $currentPath
-                }
-                else
-                {
+                } else {
                     $sourceDirPaths += $currentPath
                 }
             }
 
             # The Soure Path contains one or more directory (this directory can have files under it) and no files to be compressed.
-            if ($sourceFilePaths.Count -eq 0 -and $sourceDirPaths.Count -gt 0)
-            {
-                $currentSegmentWeight = 100/[double]$sourceDirPaths.Count
+            if ($sourceFilePaths.Count -eq 0 -and $sourceDirPaths.Count -gt 0) {
+                $currentSegmentWeight = 100 / [double]$sourceDirPaths.Count
                 $previousSegmentWeight = 0
-                foreach ($currentSourceDirPath in $sourceDirPaths)
-                {
+                foreach ($currentSourceDirPath in $sourceDirPaths) {
                     $count = CompressSingleDirHelper $currentSourceDirPath $destinationPath $compressionLevel $true $isUpdateMode $previousSegmentWeight $currentSegmentWeight
                     $numberOfItemsArchived += $count
                     $previousSegmentWeight += $currentSegmentWeight
@@ -389,8 +357,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             }
 
             # The Soure Path contains only files to be compressed.
-            elseIf ($sourceFilePaths.Count -gt 0 -and $sourceDirPaths.Count -eq 0)
-            {
+            elseIf ($sourceFilePaths.Count -gt 0 -and $sourceDirPaths.Count -eq 0) {
                 # $previousSegmentWeight is equal to 0 as there are no prior segments.
                 # $currentSegmentWeight is set to 100 as all files have equal weightage.
                 $previousSegmentWeight = 0
@@ -399,14 +366,12 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $numberOfItemsArchived = CompressFilesHelper $sourceFilePaths $destinationPath $compressionLevel $isUpdateMode $previousSegmentWeight $currentSegmentWeight
             }
             # The Soure Path contains one or more files and one or more directories (this directory can have files under it) to be compressed.
-            elseif ($sourceFilePaths.Count -gt 0 -and $sourceDirPaths.Count -gt 0)
-            {
+            elseif ($sourceFilePaths.Count -gt 0 -and $sourceDirPaths.Count -gt 0) {
                 # each directory is considered as an individual segments & all the individual files are clubed in to a separate sgemnet.
-                $currentSegmentWeight = 100/[double]($sourceDirPaths.Count + 1)
+                $currentSegmentWeight = 100 / [double]($sourceDirPaths.Count + 1)
                 $previousSegmentWeight = 0
 
-                foreach ($currentSourceDirPath in $sourceDirPaths)
-                {
+                foreach ($currentSourceDirPath in $sourceDirPaths) {
                     $count = CompressSingleDirHelper $currentSourceDirPath $destinationPath $compressionLevel $true $isUpdateMode $previousSegmentWeight $currentSegmentWeight
                     $numberOfItemsArchived += $count
                     $previousSegmentWeight += $currentSegmentWeight
@@ -419,8 +384,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             return $numberOfItemsArchived
         }
 
-        function CompressFilesHelper
-        {
+        function CompressFilesHelper {
             param
             (
                 [string[]]
@@ -447,8 +411,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             return $numberOfItemsArchived
         }
 
-        function CompressSingleDirHelper
-        {
+        function CompressSingleDirHelper {
             param
             (
                 [string]
@@ -475,46 +438,35 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
             [System.Collections.Generic.List[System.String]]$subDirFiles = @()
 
-            if ($useParentDirAsRoot)
-            {
+            if ($useParentDirAsRoot) {
                 $sourceDirInfo = New-Object -TypeName System.IO.DirectoryInfo -ArgumentList $sourceDirPath
                 $sourceDirFullName = $sourceDirInfo.Parent.FullName
 
                 # If the directory is present at the drive level the DirectoryInfo.Parent include '\' example: C:\
                 # On the other hand if the directory exists at a deper level then DirectoryInfo.Parent
                 # has just the path (without an ending '\'). example C:\source
-                if ($sourceDirFullName.Length -eq 3)
-                {
+                if ($sourceDirFullName.Length -eq 3) {
                     $modifiedSourceDirFullName = $sourceDirFullName
-                }
-                else
-                {
+                } else {
                     $modifiedSourceDirFullName = $sourceDirFullName + "\"
                 }
-            }
-            else
-            {
+            } else {
                 $sourceDirFullName = $sourceDirPath
                 $modifiedSourceDirFullName = $sourceDirFullName + "\"
             }
 
             $dirContents = Get-ChildItem -LiteralPath $sourceDirPath -Recurse
-            foreach ($currentContent in $dirContents)
-            {
+            foreach ($currentContent in $dirContents) {
                 $isContainer = $currentContent -is [System.IO.DirectoryInfo]
-                if (!$isContainer)
-                {
+                if (!$isContainer) {
                     $subDirFiles.Add($currentContent.FullName)
-                }
-                else
-                {
+                } else {
                     # The currentContent points to a directory.
                     # We need to check if the directory is an empty directory, if so such a
                     # directory has to be explictly added to the archive file.
                     # if there are no files in the directory the GetFiles() API returns an empty array.
                     $files = $currentContent.GetFiles()
-                    if ($files.Count -eq 0)
-                    {
+                    if ($files.Count -eq 0) {
                         $subDirFiles.Add($currentContent.FullName + "\")
                     }
                 }
@@ -525,8 +477,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             return $numberOfItemsArchived
         }
 
-        function ZipArchiveHelper
-        {
+        function ZipArchiveHelper {
             param
             (
                 [System.Collections.Generic.List[System.String]]
@@ -554,15 +505,13 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $numberOfItemsArchived = 0
             $fileMode = [System.IO.FileMode]::Create
             $result = Test-Path -LiteralPath $DestinationPath -PathType Leaf
-            if ($result -eq $true)
-            {
+            if ($result -eq $true) {
                 $fileMode = [System.IO.FileMode]::Open
             }
 
             Add-CompressionAssemblies
 
-            try
-            {
+            try {
                 # At this point we are sure that the archive file has write access.
                 $archiveFileStreamArgs = @($destinationPath, $fileMode)
                 $archiveFileStream = New-Object -TypeName System.IO.FileStream -ArgumentList $archiveFileStreamArgs
@@ -575,23 +524,18 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $bufferSize = 4kb
                 $buffer = New-Object Byte[] $bufferSize
 
-                foreach ($currentFilePath in $sourcePaths)
-                {
-                    if ($modifiedSourceDirFullName -ne $null -and $modifiedSourceDirFullName.Length -gt 0)
-                    {
+                foreach ($currentFilePath in $sourcePaths) {
+                    if ($modifiedSourceDirFullName -ne $null -and $modifiedSourceDirFullName.Length -gt 0) {
                         $index = $currentFilePath.IndexOf($modifiedSourceDirFullName, [System.StringComparison]::OrdinalIgnoreCase)
                         $currentFilePathSubString = $currentFilePath.Substring($index, $modifiedSourceDirFullName.Length)
                         $relativeFilePath = $currentFilePath.Replace($currentFilePathSubString, "").Trim()
-                    }
-                    else
-                    {
+                    } else {
                         $relativeFilePath = [System.IO.Path]::GetFileName($currentFilePath)
                     }
 
                     # Update mode is selected.
                     # Check to see if archive file already contains one or more zip files in it.
-                    if ($isUpdateMode -eq $true -and $zipArchive.Entries.Count -gt 0)
-                    {
+                    if ($isUpdateMode -eq $true -and $zipArchive.Entries.Count -gt 0) {
                         $entryToBeUpdated = $null
 
                         # Check if the file already exists in the archive file.
@@ -599,17 +543,14 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                         # If the file does not exist in the archive file then default to
                         # create mode and create the entry in the archive file.
 
-                        foreach ($currentArchiveEntry in $zipArchive.Entries)
-                        {
-                            if ($currentArchiveEntry.FullName -eq $relativeFilePath)
-                            {
+                        foreach ($currentArchiveEntry in $zipArchive.Entries) {
+                            if ($currentArchiveEntry.FullName -eq $relativeFilePath) {
                                 $entryToBeUpdated = $currentArchiveEntry
                                 break
                             }
                         }
 
-                        if ($entryToBeUpdated -ne $null)
-                        {
+                        if ($entryToBeUpdated -ne $null) {
                             $addItemtoArchiveFileMessage = ($LocalizedData.AddItemtoArchiveFile -f $currentFilePath)
                             $entryToBeUpdated.Delete()
                         }
@@ -620,30 +561,23 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                     # If a directory needs to be added to an archive file,
                     # by convention the .Net API's expect the path of the diretcory
                     # to end with '\' to detect the path as an directory.
-                    if (!$relativeFilePath.EndsWith("\", [StringComparison]::OrdinalIgnoreCase))
-                    {
-                        try
-                        {
-                            try
-                            {
+                    if (!$relativeFilePath.EndsWith("\", [StringComparison]::OrdinalIgnoreCase)) {
+                        try {
+                            try {
                                 $currentFileStream = [System.IO.File]::Open($currentFilePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
-                            }
-                            catch
-                            {
+                            } catch {
                                 # Failed to access the file. Write a non terminating error to the pipeline
                                 # and move on with the remaining files.
                                 $exception = $_.Exception
                                 if ($null -ne $_.Exception -and
-                                    $null -ne $_.Exception.InnerException)
-                                {
+                                    $null -ne $_.Exception.InnerException) {
                                     $exception = $_.Exception.InnerException
                                 }
                                 $errorRecord = CreateErrorRecordHelper "CompressArchiveUnauthorizedAccessError" $null ([System.Management.Automation.ErrorCategory]::PermissionDenied) $exception $currentFilePath
                                 Write-Error -ErrorRecord $errorRecord
                             }
 
-                            if ($null -ne $currentFileStream)
-                            {
+                            if ($null -ne $currentFileStream) {
                                 $srcStream = New-Object System.IO.BinaryReader $currentFileStream
 
                                 $currentArchiveEntry = $zipArchive.CreateEntry($relativeFilePath, $compression)
@@ -654,8 +588,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
                                 $destStream = New-Object System.IO.BinaryWriter $currentArchiveEntry.Open()
 
-                                while ($numberOfBytesRead = $srcStream.Read($buffer, 0, $bufferSize))
-                                {
+                                while ($numberOfBytesRead = $srcStream.Read($buffer, 0, $bufferSize)) {
                                     $destStream.Write($buffer, 0, $numberOfBytesRead)
                                     $destStream.Flush()
                                 }
@@ -663,48 +596,36 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                                 $numberOfItemsArchived += 1
                                 $addItemtoArchiveFileMessage = ($LocalizedData.AddItemtoArchiveFile -f $currentFilePath)
                             }
-                        }
-                        finally
-                        {
-                            If ($null -ne $currentFileStream)
-                            {
+                        } finally {
+                            If ($null -ne $currentFileStream) {
                                 $currentFileStream.Dispose()
                             }
-                            If ($null -ne $srcStream)
-                            {
+                            If ($null -ne $srcStream) {
                                 $srcStream.Dispose()
                             }
-                            If ($null -ne $destStream)
-                            {
+                            If ($null -ne $destStream) {
                                 $destStream.Dispose()
                             }
                         }
-                    }
-                    else
-                    {
+                    } else {
                         $currentArchiveEntry = $zipArchive.CreateEntry("$relativeFilePath", $compression)
                         $numberOfItemsArchived += 1
                         $addItemtoArchiveFileMessage = ($LocalizedData.AddItemtoArchiveFile -f $currentFilePath)
                     }
 
-                    if ($null -ne $addItemtoArchiveFileMessage)
-                    {
+                    if ($null -ne $addItemtoArchiveFileMessage) {
                         Write-Verbose $addItemtoArchiveFileMessage
                     }
 
                     $currentEntryCount += 1
                     ProgressBarHelper "Compress-Archive" $progressBarStatus $previousSegmentWeight $currentSegmentWeight $sourcePaths.Count  $currentEntryCount
                 }
-            }
-            finally
-            {
-                If ($null -ne $zipArchive)
-                {
+            } finally {
+                If ($null -ne $zipArchive) {
                     $zipArchive.Dispose()
                 }
 
-                If ($null -ne $archiveFileStream)
-                {
+                If ($null -ne $archiveFileStream) {
                     $archiveFileStream.Dispose()
                 }
 
@@ -715,42 +636,36 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             return $numberOfItemsArchived
         }
 
-<############################################################################################
+        <############################################################################################
 # ValidateArchivePathHelper: This is a helper function used to validate the archive file
 # path & its file format. The only supported archive file format is .zip
 ############################################################################################>
-        function ValidateArchivePathHelper
-        {
+        function ValidateArchivePathHelper {
             param
             (
                 [string]
                 $archiveFile
             )
 
-            if ([System.IO.File]::Exists($archiveFile))
-            {
+            if ([System.IO.File]::Exists($archiveFile)) {
                 $extension = [system.IO.Path]::GetExtension($archiveFile)
 
                 # Invalid file extension is specifed for the zip file.
-                if ($extension -ne $zipFileExtension)
-                {
+                if ($extension -ne $zipFileExtension) {
                     $errorMessage = ($LocalizedData.InvalidZipFileExtensionError -f $extension, $zipFileExtension)
                     ThrowTerminatingErrorHelper "NotSupportedArchiveFileExtension" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $extension
                 }
-            }
-            else
-            {
+            } else {
                 $errorMessage = ($LocalizedData.PathNotFoundError -f $archiveFile)
                 ThrowTerminatingErrorHelper "PathNotFound" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $archiveFile
             }
         }
 
-<############################################################################################
+        <############################################################################################
 # ExpandArchiveHelper: This is a helper function used to expand the archive file contents
 # to the specified directory.
 ############################################################################################>
-        function ExpandArchiveHelper
-        {
+        function ExpandArchiveHelper {
             param
             (
                 [string]
@@ -774,8 +689,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
             Add-CompressionAssemblies
 
-            try
-            {
+            try {
                 # The existance of archive file has already been validated by ValidateArchivePathHelper
                 # before calling this helper function.
                 $archiveFileStreamArgs = @($archiveFile, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
@@ -784,8 +698,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $zipArchiveArgs = @($archiveFileStream, [System.IO.Compression.ZipArchiveMode]::Read, $false)
                 $zipArchive = New-Object -TypeName System.IO.Compression.ZipArchive -ArgumentList $zipArchiveArgs
 
-                if ($zipArchive.Entries.Count -eq 0)
-                {
+                if ($zipArchive.Entries.Count -eq 0) {
                     $archiveFileIsEmpty = ($LocalizedData.ArchiveFileIsEmpty -f $archiveFile)
                     Write-Verbose $archiveFileIsEmpty
                     return
@@ -795,48 +708,39 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $progressBarStatus = ($LocalizedData.ExpandProgressBarText -f $archiveFile)
 
                 # The archive entries can either be empty directories or files.
-                foreach ($currentArchiveEntry in $zipArchive.Entries)
-                {
+                foreach ($currentArchiveEntry in $zipArchive.Entries) {
                     $currentArchiveEntryPath = Join-Path -Path $expandedDir -ChildPath $currentArchiveEntry.FullName
                     $extension = [system.IO.Path]::GetExtension($currentArchiveEntryPath)
 
                     # The current archive entry is an empty directory
                     # The FullName of the Archive Entry representing a directory would end with a trailing '\'.
                     if ($extension -eq [string]::Empty -and
-                        $currentArchiveEntryPath.EndsWith("\", [StringComparison]::OrdinalIgnoreCase))
-                    {
+                        $currentArchiveEntryPath.EndsWith("\", [StringComparison]::OrdinalIgnoreCase)) {
                         $pathExists = Test-Path -LiteralPath $currentArchiveEntryPath
 
                         # The current archive entry expects an empty directory.
                         # Check if the existing directory is empty. If its not empty
                         # then it means that user has added this directory by other means.
-                        if ($pathExists -eq $false)
-                        {
+                        if ($pathExists -eq $false) {
                             New-Item $currentArchiveEntryPath -ItemType Directory -Confirm:$isConfirm | Out-Null
 
-                            if (Test-Path -LiteralPath $currentArchiveEntryPath -PathType Container)
-                            {
+                            if (Test-Path -LiteralPath $currentArchiveEntryPath -PathType Container) {
                                 $addEmptyDirectorytoExpandedPathMessage = ($LocalizedData.AddItemtoArchiveFile -f $currentArchiveEntryPath)
                                 Write-Verbose $addEmptyDirectorytoExpandedPathMessage
 
                                 $expandedItems.Value += $currentArchiveEntryPath
                             }
                         }
-                    }
-                    else
-                    {
-                        try
-                        {
+                    } else {
+                        try {
                             $currentArchiveEntryFileInfo = New-Object -TypeName System.IO.FileInfo -ArgumentList $currentArchiveEntryPath
                             $parentDirExists = Test-Path -LiteralPath $currentArchiveEntryFileInfo.DirectoryName -PathType Container
 
                             # If the Parent directory of the current entry in the archive file does not exist, then create it.
-                            if ($parentDirExists -eq $false)
-                            {
+                            if ($parentDirExists -eq $false) {
                                 New-Item $currentArchiveEntryFileInfo.DirectoryName -ItemType Directory -Confirm:$isConfirm | Out-Null
 
-                                if (!(Test-Path -LiteralPath $currentArchiveEntryFileInfo.DirectoryName -PathType Container))
-                                {
+                                if (!(Test-Path -LiteralPath $currentArchiveEntryFileInfo.DirectoryName -PathType Container)) {
                                     # The directory referred by $currentArchiveEntryFileInfo.DirectoryName was not successfully created.
                                     # This could be because the user has specified -Confirm paramter when Expand-Archive was invoked
                                     # and authorization was not provided when confirmation was prompted. In such a scenario,
@@ -851,27 +755,21 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
                             # Check if the file in to which the current archive entry contents
                             # would be expanded already exists.
-                            if ($currentArchiveEntryFileInfo.Exists)
-                            {
-                                if ($force)
-                                {
+                            if ($currentArchiveEntryFileInfo.Exists) {
+                                if ($force) {
                                     Remove-Item -LiteralPath $currentArchiveEntryFileInfo.FullName -Force -ErrorVariable ev -Verbose:$isVerbose -Confirm:$isConfirm
-                                    if ($ev -ne $null)
-                                    {
+                                    if ($ev -ne $null) {
                                         $hasNonTerminatingError = $true
                                     }
 
-                                    if (Test-Path -LiteralPath $currentArchiveEntryFileInfo.FullName -PathType Leaf)
-                                    {
+                                    if (Test-Path -LiteralPath $currentArchiveEntryFileInfo.FullName -PathType Leaf) {
                                         # The file referred by $currentArchiveEntryFileInfo.FullName was not successfully removed.
                                         # This could be because the user has specified -Confirm paramter when Expand-Archive was invoked
                                         # and authorization was not provided when confirmation was prompted. In such a scenario,
                                         # we skip the current file in the archive and continue with the remaining archive file contents.
                                         Continue
                                     }
-                                }
-                                else
-                                {
+                                } else {
                                     # Write non-terminating error to the pipeline.
                                     $errorMessage = ($LocalizedData.FileExistsError -f $currentArchiveEntryFileInfo.FullName, $archiveFile, $currentArchiveEntryFileInfo.FullName, $currentArchiveEntryFileInfo.FullName)
                                     $errorRecord = CreateErrorRecordHelper "ExpandArchiveFileExists" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidOperation) $null $currentArchiveEntryFileInfo.FullName
@@ -880,8 +778,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                                 }
                             }
 
-                            if (!$hasNonTerminatingError)
-                            {
+                            if (!$hasNonTerminatingError) {
                                 [System.IO.Compression.ZipFileExtensions]::ExtractToFile($currentArchiveEntry, $currentArchiveEntryPath, $false)
 
                                 # Add the expanded file path to the $expandedItems array,
@@ -893,16 +790,12 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                                 $addFiletoExpandedPathMessage = ($LocalizedData.CreateFileAtExpandedPath -f $currentArchiveEntryPath)
                                 Write-Verbose $addFiletoExpandedPathMessage
                             }
-                        }
-                        finally
-                        {
-                            If ($null -ne $destStream)
-                            {
+                        } finally {
+                            If ($null -ne $destStream) {
                                 $destStream.Dispose()
                             }
 
-                            If ($null -ne $srcStream)
-                            {
+                            If ($null -ne $srcStream) {
                                 $srcStream.Dispose()
                             }
                         }
@@ -915,16 +808,12 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                     $currentSegmentWeight = 100
                     ProgressBarHelper "Expand-Archive" $progressBarStatus $previousSegmentWeight $currentSegmentWeight $zipArchive.Entries.Count  $currentEntryCount
                 }
-            }
-            finally
-            {
-                If ($null -ne $zipArchive)
-                {
+            } finally {
+                If ($null -ne $zipArchive) {
                     $zipArchive.Dispose()
                 }
 
-                If ($null -ne $archiveFileStream)
-                {
+                If ($null -ne $archiveFileStream) {
                     $archiveFileStream.Dispose()
                 }
 
@@ -933,13 +822,12 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             }
         }
 
-<############################################################################################
+        <############################################################################################
 # ProgressBarHelper: This is a helper function used to display progress message.
 # This function is used by both Compress-Archive & Expand-Archive to display archive file
 # creation/expansion progress.
 ############################################################################################>
-        function ProgressBarHelper
-        {
+        function ProgressBarHelper {
             param
             (
                 [string]
@@ -964,22 +852,20 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             if ($currentEntryCount -gt 0 -and
                 $totalNumberofEntries -gt 0 -and
                 $previousSegmentWeight -ge 0 -and
-                $currentSegmentWeight -gt 0)
-            {
-                $entryDefaultWeight = $currentSegmentWeight/[double]$totalNumberofEntries
+                $currentSegmentWeight -gt 0) {
+                $entryDefaultWeight = $currentSegmentWeight / [double]$totalNumberofEntries
 
                 $percentComplete = $previousSegmentWeight + ($entryDefaultWeight * $currentEntryCount)
                 Write-Progress -Activity $cmdletName -Status $status -PercentComplete $percentComplete
             }
         }
 
-<############################################################################################
+        <############################################################################################
 # CSVHelper: This is a helper function used to append comma after each path specifid by
 # the SourcePath array. This helper function is used to display all the user supplied paths
 # in the WhatIf message.
 ############################################################################################>
-        function CSVHelper
-        {
+        function CSVHelper {
             param
             (
                 [string[]]
@@ -987,34 +873,26 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             )
 
             # SourcePath has already been validated by the calling funcation.
-            if ($sourcePath.Count -gt 1)
-            {
+            if ($sourcePath.Count -gt 1) {
                 $sourcePathInCsvFormat = "`n"
-                for ($currentIndex = 0; $currentIndex -lt $sourcePath.Count; $currentIndex++)
-                {
-                    if ($currentIndex -eq $sourcePath.Count - 1)
-                    {
+                for ($currentIndex = 0; $currentIndex -lt $sourcePath.Count; $currentIndex++) {
+                    if ($currentIndex -eq $sourcePath.Count - 1) {
                         $sourcePathInCsvFormat += $sourcePath[$currentIndex]
-                    }
-                    else
-                    {
+                    } else {
                         $sourcePathInCsvFormat += $sourcePath[$currentIndex] + "`n"
                     }
                 }
-            }
-            else
-            {
+            } else {
                 $sourcePathInCsvFormat = $sourcePath
             }
 
             return $sourcePathInCsvFormat
         }
 
-<############################################################################################
+        <############################################################################################
 # ThrowTerminatingErrorHelper: This is a helper function used to throw terminating error.
 ############################################################################################>
-        function ThrowTerminatingErrorHelper
-        {
+        function ThrowTerminatingErrorHelper {
             param
             (
                 [string]
@@ -1033,12 +911,9 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $innerException
             )
 
-            if ($innerException -eq $null)
-            {
+            if ($innerException -eq $null) {
                 $exception = New-object System.IO.IOException $errorMessage
-            }
-            else
-            {
+            } else {
                 $exception = New-Object System.IO.IOException $errorMessage, $innerException
             }
 
@@ -1047,11 +922,10 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $PSCmdlet.ThrowTerminatingError($errorRecord)
         }
 
-<############################################################################################
+        <############################################################################################
 # CreateErrorRecordHelper: This is a helper function used to create an ErrorRecord
 ############################################################################################>
-        function CreateErrorRecordHelper
-        {
+        function CreateErrorRecordHelper {
             param
             (
                 [string]
@@ -1070,8 +944,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $targetObject
             )
 
-            if ($null -eq $exception)
-            {
+            if ($null -eq $exception) {
                 $exception = New-Object System.IO.IOException $errorMessage
             }
 
@@ -1082,22 +955,19 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
         $inputPaths = @()
         $destinationParentDir = [system.IO.Path]::GetDirectoryName($DestinationPath)
-        if ($null -eq $destinationParentDir)
-        {
+        if ($null -eq $destinationParentDir) {
             $errorMessage = ($LocalizedData.InvalidDestinationPath -f $DestinationPath)
             ThrowTerminatingErrorHelper "InvalidArchiveFilePath" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $DestinationPath
         }
 
-        if ($destinationParentDir -eq [string]::Empty)
-        {
+        if ($destinationParentDir -eq [string]::Empty) {
             $destinationParentDir = '.'
         }
 
         $achiveFileName = [system.IO.Path]::GetFileName($DestinationPath)
         $destinationParentDir = GetResolvedPathHelper $destinationParentDir $false $PSCmdlet
 
-        if ($destinationParentDir.Count -gt 1)
-        {
+        if ($destinationParentDir.Count -gt 1) {
             $errorMessage = ($LocalizedData.InvalidArchiveFilePathError -f $DestinationPath, "DestinationPath", "DestinationPath")
             ThrowTerminatingErrorHelper "InvalidArchiveFilePath" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $DestinationPath
         }
@@ -1109,18 +979,14 @@ PreparingToExpandVerboseMessage=Preparing to expand...
         $extension = [system.IO.Path]::GetExtension($DestinationPath)
 
         # If user does not specify .Zip extension, we append it.
-        If ($extension -eq [string]::Empty)
-        {
+        If ($extension -eq [string]::Empty) {
             $DestinationPathWithOutExtension = $DestinationPath
             $DestinationPath = $DestinationPathWithOutExtension + $zipFileExtension
             $appendArchiveFileExtensionMessage = ($LocalizedData.AppendArchiveFileExtensionMessage -f $DestinationPathWithOutExtension, $DestinationPath)
             Write-Verbose $appendArchiveFileExtensionMessage
-        }
-        else
-        {
+        } else {
             # Invalid file extension is specified for the zip file to be created.
-            if ($extension -ne $zipFileExtension)
-            {
+            if ($extension -ne $zipFileExtension) {
                 $errorMessage = ($LocalizedData.InvalidZipFileExtensionError -f $extension, $zipFileExtension)
                 ThrowTerminatingErrorHelper "NotSupportedArchiveFileExtension" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $extension
             }
@@ -1128,27 +994,23 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
         $archiveFileExist = Test-Path -LiteralPath $DestinationPath -PathType Leaf
 
-        if ($archiveFileExist -and ($Update -eq $false -and $Force -eq $false))
-        {
+        if ($archiveFileExist -and ($Update -eq $false -and $Force -eq $false)) {
             $errorMessage = ($LocalizedData.ZipFileExistError -f $DestinationPath)
             ThrowTerminatingErrorHelper "ArchiveFileExists" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $DestinationPath
         }
 
         # If archive file already exists and if -Update is specified, then we check to see
         # if we have write access permission to update the existing archive file.
-        if ($archiveFileExist -and $Update -eq $true)
-        {
+        if ($archiveFileExist -and $Update -eq $true) {
             $item = Get-Item -Path $DestinationPath
-            if ($item.Attributes.ToString().Contains("ReadOnly"))
-            {
+            if ($item.Attributes.ToString().Contains("ReadOnly")) {
                 $errorMessage = ($LocalizedData.ArchiveFileIsReadOnly -f $DestinationPath)
                 ThrowTerminatingErrorHelper "ArchiveFileIsReadOnly" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidOperation) $DestinationPath
             }
         }
 
         $isWhatIf = $psboundparameters.ContainsKey("WhatIf")
-        if (!$isWhatIf)
-        {
+        if (!$isWhatIf) {
             $preparingToCompressVerboseMessage = ($LocalizedData.PreparingToCompressVerboseMessage)
             Write-Verbose $preparingToCompressVerboseMessage
 
@@ -1156,29 +1018,24 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             ProgressBarHelper "Compress-Archive" $progressBarStatus 0 100 100 1
         }
     }
-    PROCESS
-    {
+    PROCESS {
         if ($PsCmdlet.ParameterSetName -eq "Path" -or
             $PsCmdlet.ParameterSetName -eq "PathWithForce" -or
-            $PsCmdlet.ParameterSetName -eq "PathWithUpdate")
-        {
+            $PsCmdlet.ParameterSetName -eq "PathWithUpdate") {
             $inputPaths += $Path
         }
 
         if ($PsCmdlet.ParameterSetName -eq "LiteralPath" -or
             $PsCmdlet.ParameterSetName -eq "LiteralPathWithForce" -or
-            $PsCmdlet.ParameterSetName -eq "LiteralPathWithUpdate")
-        {
+            $PsCmdlet.ParameterSetName -eq "LiteralPathWithUpdate") {
             $inputPaths += $LiteralPath
         }
     }
-    END
-    {
+    END {
         # If archive file already exists and if -Force is specified, we delete the
         # existing artchive file and create a brand new one.
         if (($PsCmdlet.ParameterSetName -eq "PathWithForce" -or
-                $PsCmdlet.ParameterSetName -eq "LiteralPathWithForce") -and $archiveFileExist)
-        {
+                $PsCmdlet.ParameterSetName -eq "LiteralPathWithForce") -and $archiveFileExist) {
             Remove-Item -Path $DestinationPath -Force -ErrorAction Stop
         }
 
@@ -1188,8 +1045,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
         $isLiteralPathUsed = $false
         if ($PsCmdlet.ParameterSetName -eq "LiteralPath" -or
             $PsCmdlet.ParameterSetName -eq "LiteralPathWithForce" -or
-            $PsCmdlet.ParameterSetName -eq "LiteralPathWithUpdate")
-        {
+            $PsCmdlet.ParameterSetName -eq "LiteralPathWithUpdate") {
             $isLiteralPathUsed = $true
         }
 
@@ -1202,10 +1058,8 @@ PreparingToExpandVerboseMessage=Preparing to expand...
         # CSVHelper: This is a helper function used to append comma after each path specifid by
         # the $sourcePath array. The comma saperated paths are displayed in the -WhatIf message.
         $sourcePathInCsvFormat = CSVHelper $sourcePath
-        if ($pscmdlet.ShouldProcess($sourcePathInCsvFormat))
-        {
-            try
-            {
+        if ($pscmdlet.ShouldProcess($sourcePathInCsvFormat)) {
+            try {
                 # StopProcessing is not avaliable in Script cmdlets. However the pipleline execution
                 # is terminated when ever 'CTRL + C' is entered by user to terminate the cmdlet execution.
                 # The finally block is executed whenever pipleline is terminated.
@@ -1216,22 +1070,18 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $numberOfItemsArchived = CompressArchiveHelper $sourcePath $DestinationPath $CompressionLevel $Update
 
                 $isArchiveFileProcessingComplete = $true
-            }
-            finally
-            {
+            } finally {
                 # The $isArchiveFileProcessingComplete would be set to $false if user has typed 'CTRL + C' to
                 # terminate the cmdlet execution or if an unhandled exception is thrown.
                 # $numberOfItemsArchived contains the count of number of files or directories add to the archive file.
                 # If the newly created archive file is empty then we delete it as its not usable.
                 if (($isArchiveFileProcessingComplete -eq $false) -or
-                    ($numberOfItemsArchived -eq 0))
-                {
+                    ($numberOfItemsArchived -eq 0)) {
                     $DeleteArchiveFileMessage = ($LocalizedData.DeleteArchiveFile -f $DestinationPath)
                     Write-Verbose $DeleteArchiveFileMessage
 
                     # delete the partial archive file created.
-                    if (Test-Path $DestinationPath)
-                    {
+                    if (Test-Path $DestinationPath) {
                         Remove-Item -LiteralPath $DestinationPath -Force -Recurse -ErrorAction SilentlyContinue
                     }
                 }
@@ -1240,8 +1090,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
     }
 }
 
-function Expand-Archive
-{
+function Expand-Archive {
     <#
         .SYNOPSIS
             Extracts files from a specified archive (zipped) file.
@@ -1282,47 +1131,46 @@ function Expand-Archive
             This command extracts the contents of an existing archive file in the current folder, Draft.zip, into the folder specified by the DestinationPath parameter, C:\Reference.
     #>
     [CmdletBinding(
-                DefaultParameterSetName = "Path",
-                SupportsShouldProcess = $true,
-                HelpUri = "http://go.microsoft.com/fwlink/?LinkID=393253")]
+        DefaultParameterSetName = "Path",
+        SupportsShouldProcess = $true,
+        HelpUri = "http://go.microsoft.com/fwlink/?LinkID=393253")]
     param
     (
         [parameter (
-                    mandatory = $true,
-                    Position = 0,
-                    ParameterSetName = "Path",
-                    ValueFromPipeline = $true,
-                    ValueFromPipelineByPropertyName = $true)]
+            mandatory = $true,
+            Position = 0,
+            ParameterSetName = "Path",
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Path,
 
         [parameter (
-                    mandatory = $true,
-                    ParameterSetName = "LiteralPath",
-                    ValueFromPipelineByPropertyName = $true)]
+            mandatory = $true,
+            ParameterSetName = "LiteralPath",
+            ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [Alias("PSPath")]
         [string]
         $LiteralPath,
 
         [parameter (mandatory = $false,
-                    Position = 1,
-                    ValueFromPipeline = $false,
-                    ValueFromPipelineByPropertyName = $false)]
+            Position = 1,
+            ValueFromPipeline = $false,
+            ValueFromPipelineByPropertyName = $false)]
         [ValidateNotNullOrEmpty()]
         [string]
         $DestinationPath,
 
         [parameter (mandatory = $false,
-                    ValueFromPipeline = $false,
-                    ValueFromPipelineByPropertyName = $false)]
+            ValueFromPipeline = $false,
+            ValueFromPipelineByPropertyName = $false)]
         [switch]
         $Force
     )
 
-    BEGIN
-    {
+    BEGIN {
         Add-Type -AssemblyName System.IO.Compression -ErrorAction Ignore
         Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Ignore
 
@@ -1351,8 +1199,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 '@
 
         #region Utility Functions
-        function GetResolvedPathHelper
-        {
+        function GetResolvedPathHelper {
             param
             (
                 [string[]]
@@ -1368,29 +1215,21 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $resolvedPaths = @()
 
             # null and empty check are are already done on Path parameter at the cmdlet layer.
-            foreach ($currentPath in $path)
-            {
-                try
-                {
-                    if ($isLiteralPath)
-                    {
+            foreach ($currentPath in $path) {
+                try {
+                    if ($isLiteralPath) {
                         $currentResolvedPaths = Resolve-Path -LiteralPath $currentPath -ErrorAction Stop
-                    }
-                    else
-                    {
+                    } else {
                         $currentResolvedPaths = Resolve-Path -Path $currentPath -ErrorAction Stop
                     }
-                }
-                catch
-                {
+                } catch {
                     $errorMessage = ($LocalizedData.PathNotFoundError -f $currentPath)
                     $exception = New-Object System.InvalidOperationException $errorMessage, $_.Exception
                     $errorRecord = CreateErrorRecordHelper "ArchiveCmdletPathNotFound" $null ([System.Management.Automation.ErrorCategory]::InvalidArgument) $exception $currentPath
                     $callerPSCmdlet.ThrowTerminatingError($errorRecord)
                 }
 
-                foreach ($currentResolvedPath in $currentResolvedPaths)
-                {
+                foreach ($currentResolvedPath in $currentResolvedPaths) {
                     $resolvedPaths += $currentResolvedPath.ProviderPath
                 }
             }
@@ -1398,18 +1237,15 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $resolvedPaths
         }
 
-        function Add-CompressionAssemblies
-        {
+        function Add-CompressionAssemblies {
 
-            if ($PSEdition -eq "Desktop")
-            {
+            if ($PSEdition -eq "Desktop") {
                 Add-Type -AssemblyName System.IO.Compression
                 Add-Type -AssemblyName System.IO.Compression.FileSystem
             }
         }
 
-        function IsValidFileSystemPath
-        {
+        function IsValidFileSystemPath {
             param
             (
                 [string[]]
@@ -1419,10 +1255,8 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $result = $true;
 
             # null and empty check are are already done on Path parameter at the cmdlet layer.
-            foreach ($currentPath in $path)
-            {
-                if (!([System.IO.File]::Exists($currentPath) -or [System.IO.Directory]::Exists($currentPath)))
-                {
+            foreach ($currentPath in $path) {
+                if (!([System.IO.File]::Exists($currentPath) -or [System.IO.Directory]::Exists($currentPath))) {
                     $errorMessage = ($LocalizedData.PathNotFoundError -f $currentPath)
                     ThrowTerminatingErrorHelper "PathNotFound" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $currentPath
                 }
@@ -1432,8 +1266,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
         }
 
 
-        function ValidateDuplicateFileSystemPath
-        {
+        function ValidateDuplicateFileSystemPath {
             param
             (
                 [string]
@@ -1446,23 +1279,18 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $uniqueInputPaths = @()
 
             # null and empty check are are already done on Path parameter at the cmdlet layer.
-            foreach ($currentPath in $path)
-            {
+            foreach ($currentPath in $path) {
                 $currentInputPath = $currentPath.ToUpper()
-                if ($uniqueInputPaths.Contains($currentInputPath))
-                {
+                if ($uniqueInputPaths.Contains($currentInputPath)) {
                     $errorMessage = ($LocalizedData.DuplicatePathFoundError -f $inputParameter, $currentPath, $inputParameter)
                     ThrowTerminatingErrorHelper "DuplicatePathFound" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $currentPath
-                }
-                else
-                {
+                } else {
                     $uniqueInputPaths += $currentInputPath
                 }
             }
         }
 
-        function CompressionLevelMapper
-        {
+        function CompressionLevelMapper {
             param
             (
                 [string]
@@ -1472,14 +1300,11 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $compressionLevelFormat = [System.IO.Compression.CompressionLevel]::Optimal
 
             # CompressionLevel format is already validated at the cmdlet layer.
-            switch ($compressionLevel.ToString())
-            {
-                "Fastest"
-                {
+            switch ($compressionLevel.ToString()) {
+                "Fastest" {
                     $compressionLevelFormat = [System.IO.Compression.CompressionLevel]::Fastest
                 }
-                "NoCompression"
-                {
+                "NoCompression" {
                     $compressionLevelFormat = [System.IO.Compression.CompressionLevel]::NoCompression
                 }
             }
@@ -1487,8 +1312,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             return $compressionLevelFormat
         }
 
-        function CompressArchiveHelper
-        {
+        function CompressArchiveHelper {
             param
             (
                 [string[]]
@@ -1508,26 +1332,20 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $sourceFilePaths = @()
             $sourceDirPaths = @()
 
-            foreach ($currentPath in $sourcePath)
-            {
+            foreach ($currentPath in $sourcePath) {
                 $result = Test-Path -LiteralPath $currentPath -PathType Leaf
-                if ($result -eq $true)
-                {
+                if ($result -eq $true) {
                     $sourceFilePaths += $currentPath
-                }
-                else
-                {
+                } else {
                     $sourceDirPaths += $currentPath
                 }
             }
 
             # The Soure Path contains one or more directory (this directory can have files under it) and no files to be compressed.
-            if ($sourceFilePaths.Count -eq 0 -and $sourceDirPaths.Count -gt 0)
-            {
-                $currentSegmentWeight = 100/[double]$sourceDirPaths.Count
+            if ($sourceFilePaths.Count -eq 0 -and $sourceDirPaths.Count -gt 0) {
+                $currentSegmentWeight = 100 / [double]$sourceDirPaths.Count
                 $previousSegmentWeight = 0
-                foreach ($currentSourceDirPath in $sourceDirPaths)
-                {
+                foreach ($currentSourceDirPath in $sourceDirPaths) {
                     $count = CompressSingleDirHelper $currentSourceDirPath $destinationPath $compressionLevel $true $isUpdateMode $previousSegmentWeight $currentSegmentWeight
                     $numberOfItemsArchived += $count
                     $previousSegmentWeight += $currentSegmentWeight
@@ -1535,8 +1353,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             }
 
             # The Soure Path contains only files to be compressed.
-            elseIf ($sourceFilePaths.Count -gt 0 -and $sourceDirPaths.Count -eq 0)
-            {
+            elseIf ($sourceFilePaths.Count -gt 0 -and $sourceDirPaths.Count -eq 0) {
                 # $previousSegmentWeight is equal to 0 as there are no prior segments.
                 # $currentSegmentWeight is set to 100 as all files have equal weightage.
                 $previousSegmentWeight = 0
@@ -1545,14 +1362,12 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $numberOfItemsArchived = CompressFilesHelper $sourceFilePaths $destinationPath $compressionLevel $isUpdateMode $previousSegmentWeight $currentSegmentWeight
             }
             # The Soure Path contains one or more files and one or more directories (this directory can have files under it) to be compressed.
-            elseif ($sourceFilePaths.Count -gt 0 -and $sourceDirPaths.Count -gt 0)
-            {
+            elseif ($sourceFilePaths.Count -gt 0 -and $sourceDirPaths.Count -gt 0) {
                 # each directory is considered as an individual segments & all the individual files are clubed in to a separate sgemnet.
-                $currentSegmentWeight = 100/[double]($sourceDirPaths.Count + 1)
+                $currentSegmentWeight = 100 / [double]($sourceDirPaths.Count + 1)
                 $previousSegmentWeight = 0
 
-                foreach ($currentSourceDirPath in $sourceDirPaths)
-                {
+                foreach ($currentSourceDirPath in $sourceDirPaths) {
                     $count = CompressSingleDirHelper $currentSourceDirPath $destinationPath $compressionLevel $true $isUpdateMode $previousSegmentWeight $currentSegmentWeight
                     $numberOfItemsArchived += $count
                     $previousSegmentWeight += $currentSegmentWeight
@@ -1565,8 +1380,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             return $numberOfItemsArchived
         }
 
-        function CompressFilesHelper
-        {
+        function CompressFilesHelper {
             param
             (
                 [string[]]
@@ -1593,8 +1407,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             return $numberOfItemsArchived
         }
 
-        function CompressSingleDirHelper
-        {
+        function CompressSingleDirHelper {
             param
             (
                 [string]
@@ -1621,46 +1434,35 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
             [System.Collections.Generic.List[System.String]]$subDirFiles = @()
 
-            if ($useParentDirAsRoot)
-            {
+            if ($useParentDirAsRoot) {
                 $sourceDirInfo = New-Object -TypeName System.IO.DirectoryInfo -ArgumentList $sourceDirPath
                 $sourceDirFullName = $sourceDirInfo.Parent.FullName
 
                 # If the directory is present at the drive level the DirectoryInfo.Parent include '\' example: C:\
                 # On the other hand if the directory exists at a deper level then DirectoryInfo.Parent
                 # has just the path (without an ending '\'). example C:\source
-                if ($sourceDirFullName.Length -eq 3)
-                {
+                if ($sourceDirFullName.Length -eq 3) {
                     $modifiedSourceDirFullName = $sourceDirFullName
-                }
-                else
-                {
+                } else {
                     $modifiedSourceDirFullName = $sourceDirFullName + "\"
                 }
-            }
-            else
-            {
+            } else {
                 $sourceDirFullName = $sourceDirPath
                 $modifiedSourceDirFullName = $sourceDirFullName + "\"
             }
 
             $dirContents = Get-ChildItem -LiteralPath $sourceDirPath -Recurse
-            foreach ($currentContent in $dirContents)
-            {
+            foreach ($currentContent in $dirContents) {
                 $isContainer = $currentContent -is [System.IO.DirectoryInfo]
-                if (!$isContainer)
-                {
+                if (!$isContainer) {
                     $subDirFiles.Add($currentContent.FullName)
-                }
-                else
-                {
+                } else {
                     # The currentContent points to a directory.
                     # We need to check if the directory is an empty directory, if so such a
                     # directory has to be explictly added to the archive file.
                     # if there are no files in the directory the GetFiles() API returns an empty array.
                     $files = $currentContent.GetFiles()
-                    if ($files.Count -eq 0)
-                    {
+                    if ($files.Count -eq 0) {
                         $subDirFiles.Add($currentContent.FullName + "\")
                     }
                 }
@@ -1671,8 +1473,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             return $numberOfItemsArchived
         }
 
-        function ZipArchiveHelper
-        {
+        function ZipArchiveHelper {
             param
             (
                 [System.Collections.Generic.List[System.String]]
@@ -1700,15 +1501,13 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $numberOfItemsArchived = 0
             $fileMode = [System.IO.FileMode]::Create
             $result = Test-Path -LiteralPath $DestinationPath -PathType Leaf
-            if ($result -eq $true)
-            {
+            if ($result -eq $true) {
                 $fileMode = [System.IO.FileMode]::Open
             }
 
             Add-CompressionAssemblies
 
-            try
-            {
+            try {
                 # At this point we are sure that the archive file has write access.
                 $archiveFileStreamArgs = @($destinationPath, $fileMode)
                 $archiveFileStream = New-Object -TypeName System.IO.FileStream -ArgumentList $archiveFileStreamArgs
@@ -1721,23 +1520,18 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $bufferSize = 4kb
                 $buffer = New-Object Byte[] $bufferSize
 
-                foreach ($currentFilePath in $sourcePaths)
-                {
-                    if ($modifiedSourceDirFullName -ne $null -and $modifiedSourceDirFullName.Length -gt 0)
-                    {
+                foreach ($currentFilePath in $sourcePaths) {
+                    if ($modifiedSourceDirFullName -ne $null -and $modifiedSourceDirFullName.Length -gt 0) {
                         $index = $currentFilePath.IndexOf($modifiedSourceDirFullName, [System.StringComparison]::OrdinalIgnoreCase)
                         $currentFilePathSubString = $currentFilePath.Substring($index, $modifiedSourceDirFullName.Length)
                         $relativeFilePath = $currentFilePath.Replace($currentFilePathSubString, "").Trim()
-                    }
-                    else
-                    {
+                    } else {
                         $relativeFilePath = [System.IO.Path]::GetFileName($currentFilePath)
                     }
 
                     # Update mode is selected.
                     # Check to see if archive file already contains one or more zip files in it.
-                    if ($isUpdateMode -eq $true -and $zipArchive.Entries.Count -gt 0)
-                    {
+                    if ($isUpdateMode -eq $true -and $zipArchive.Entries.Count -gt 0) {
                         $entryToBeUpdated = $null
 
                         # Check if the file already exists in the archive file.
@@ -1745,17 +1539,14 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                         # If the file does not exist in the archive file then default to
                         # create mode and create the entry in the archive file.
 
-                        foreach ($currentArchiveEntry in $zipArchive.Entries)
-                        {
-                            if ($currentArchiveEntry.FullName -eq $relativeFilePath)
-                            {
+                        foreach ($currentArchiveEntry in $zipArchive.Entries) {
+                            if ($currentArchiveEntry.FullName -eq $relativeFilePath) {
                                 $entryToBeUpdated = $currentArchiveEntry
                                 break
                             }
                         }
 
-                        if ($entryToBeUpdated -ne $null)
-                        {
+                        if ($entryToBeUpdated -ne $null) {
                             $addItemtoArchiveFileMessage = ($LocalizedData.AddItemtoArchiveFile -f $currentFilePath)
                             $entryToBeUpdated.Delete()
                         }
@@ -1766,30 +1557,23 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                     # If a directory needs to be added to an archive file,
                     # by convention the .Net API's expect the path of the diretcory
                     # to end with '\' to detect the path as an directory.
-                    if (!$relativeFilePath.EndsWith("\", [StringComparison]::OrdinalIgnoreCase))
-                    {
-                        try
-                        {
-                            try
-                            {
+                    if (!$relativeFilePath.EndsWith("\", [StringComparison]::OrdinalIgnoreCase)) {
+                        try {
+                            try {
                                 $currentFileStream = [System.IO.File]::Open($currentFilePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
-                            }
-                            catch
-                            {
+                            } catch {
                                 # Failed to access the file. Write a non terminating error to the pipeline
                                 # and move on with the remaining files.
                                 $exception = $_.Exception
                                 if ($null -ne $_.Exception -and
-                                    $null -ne $_.Exception.InnerException)
-                                {
+                                    $null -ne $_.Exception.InnerException) {
                                     $exception = $_.Exception.InnerException
                                 }
                                 $errorRecord = CreateErrorRecordHelper "CompressArchiveUnauthorizedAccessError" $null ([System.Management.Automation.ErrorCategory]::PermissionDenied) $exception $currentFilePath
                                 Write-Error -ErrorRecord $errorRecord
                             }
 
-                            if ($null -ne $currentFileStream)
-                            {
+                            if ($null -ne $currentFileStream) {
                                 $srcStream = New-Object System.IO.BinaryReader $currentFileStream
 
                                 $currentArchiveEntry = $zipArchive.CreateEntry($relativeFilePath, $compression)
@@ -1800,8 +1584,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
                                 $destStream = New-Object System.IO.BinaryWriter $currentArchiveEntry.Open()
 
-                                while ($numberOfBytesRead = $srcStream.Read($buffer, 0, $bufferSize))
-                                {
+                                while ($numberOfBytesRead = $srcStream.Read($buffer, 0, $bufferSize)) {
                                     $destStream.Write($buffer, 0, $numberOfBytesRead)
                                     $destStream.Flush()
                                 }
@@ -1809,48 +1592,36 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                                 $numberOfItemsArchived += 1
                                 $addItemtoArchiveFileMessage = ($LocalizedData.AddItemtoArchiveFile -f $currentFilePath)
                             }
-                        }
-                        finally
-                        {
-                            If ($null -ne $currentFileStream)
-                            {
+                        } finally {
+                            If ($null -ne $currentFileStream) {
                                 $currentFileStream.Dispose()
                             }
-                            If ($null -ne $srcStream)
-                            {
+                            If ($null -ne $srcStream) {
                                 $srcStream.Dispose()
                             }
-                            If ($null -ne $destStream)
-                            {
+                            If ($null -ne $destStream) {
                                 $destStream.Dispose()
                             }
                         }
-                    }
-                    else
-                    {
+                    } else {
                         $currentArchiveEntry = $zipArchive.CreateEntry("$relativeFilePath", $compression)
                         $numberOfItemsArchived += 1
                         $addItemtoArchiveFileMessage = ($LocalizedData.AddItemtoArchiveFile -f $currentFilePath)
                     }
 
-                    if ($null -ne $addItemtoArchiveFileMessage)
-                    {
+                    if ($null -ne $addItemtoArchiveFileMessage) {
                         Write-Verbose $addItemtoArchiveFileMessage
                     }
 
                     $currentEntryCount += 1
                     ProgressBarHelper "Compress-Archive" $progressBarStatus $previousSegmentWeight $currentSegmentWeight $sourcePaths.Count  $currentEntryCount
                 }
-            }
-            finally
-            {
-                If ($null -ne $zipArchive)
-                {
+            } finally {
+                If ($null -ne $zipArchive) {
                     $zipArchive.Dispose()
                 }
 
-                If ($null -ne $archiveFileStream)
-                {
+                If ($null -ne $archiveFileStream) {
                     $archiveFileStream.Dispose()
                 }
 
@@ -1861,42 +1632,36 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             return $numberOfItemsArchived
         }
 
-<############################################################################################
+        <############################################################################################
 # ValidateArchivePathHelper: This is a helper function used to validate the archive file
 # path & its file format. The only supported archive file format is .zip
 ############################################################################################>
-        function ValidateArchivePathHelper
-        {
+        function ValidateArchivePathHelper {
             param
             (
                 [string]
                 $archiveFile
             )
 
-            if ([System.IO.File]::Exists($archiveFile))
-            {
+            if ([System.IO.File]::Exists($archiveFile)) {
                 $extension = [system.IO.Path]::GetExtension($archiveFile)
 
                 # Invalid file extension is specifed for the zip file.
-                if ($extension -ne $zipFileExtension)
-                {
+                if ($extension -ne $zipFileExtension) {
                     $errorMessage = ($LocalizedData.InvalidZipFileExtensionError -f $extension, $zipFileExtension)
                     ThrowTerminatingErrorHelper "NotSupportedArchiveFileExtension" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $extension
                 }
-            }
-            else
-            {
+            } else {
                 $errorMessage = ($LocalizedData.PathNotFoundError -f $archiveFile)
                 ThrowTerminatingErrorHelper "PathNotFound" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $archiveFile
             }
         }
 
-<############################################################################################
+        <############################################################################################
 # ExpandArchiveHelper: This is a helper function used to expand the archive file contents
 # to the specified directory.
 ############################################################################################>
-        function ExpandArchiveHelper
-        {
+        function ExpandArchiveHelper {
             param
             (
                 [string]
@@ -1920,8 +1685,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
             Add-CompressionAssemblies
 
-            try
-            {
+            try {
                 # The existance of archive file has already been validated by ValidateArchivePathHelper
                 # before calling this helper function.
                 $archiveFileStreamArgs = @($archiveFile, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
@@ -1930,8 +1694,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $zipArchiveArgs = @($archiveFileStream, [System.IO.Compression.ZipArchiveMode]::Read, $false)
                 $zipArchive = New-Object -TypeName System.IO.Compression.ZipArchive -ArgumentList $zipArchiveArgs
 
-                if ($zipArchive.Entries.Count -eq 0)
-                {
+                if ($zipArchive.Entries.Count -eq 0) {
                     $archiveFileIsEmpty = ($LocalizedData.ArchiveFileIsEmpty -f $archiveFile)
                     Write-Verbose $archiveFileIsEmpty
                     return
@@ -1941,48 +1704,39 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $progressBarStatus = ($LocalizedData.ExpandProgressBarText -f $archiveFile)
 
                 # The archive entries can either be empty directories or files.
-                foreach ($currentArchiveEntry in $zipArchive.Entries)
-                {
+                foreach ($currentArchiveEntry in $zipArchive.Entries) {
                     $currentArchiveEntryPath = Join-Path -Path $expandedDir -ChildPath $currentArchiveEntry.FullName
                     $extension = [system.IO.Path]::GetExtension($currentArchiveEntryPath)
 
                     # The current archive entry is an empty directory
                     # The FullName of the Archive Entry representing a directory would end with a trailing '\'.
                     if ($extension -eq [string]::Empty -and
-                        $currentArchiveEntryPath.EndsWith("\", [StringComparison]::OrdinalIgnoreCase))
-                    {
+                        $currentArchiveEntryPath.EndsWith("\", [StringComparison]::OrdinalIgnoreCase)) {
                         $pathExists = Test-Path -LiteralPath $currentArchiveEntryPath
 
                         # The current archive entry expects an empty directory.
                         # Check if the existing directory is empty. If its not empty
                         # then it means that user has added this directory by other means.
-                        if ($pathExists -eq $false)
-                        {
+                        if ($pathExists -eq $false) {
                             New-Item $currentArchiveEntryPath -ItemType Directory -Confirm:$isConfirm | Out-Null
 
-                            if (Test-Path -LiteralPath $currentArchiveEntryPath -PathType Container)
-                            {
+                            if (Test-Path -LiteralPath $currentArchiveEntryPath -PathType Container) {
                                 $addEmptyDirectorytoExpandedPathMessage = ($LocalizedData.AddItemtoArchiveFile -f $currentArchiveEntryPath)
                                 Write-Verbose $addEmptyDirectorytoExpandedPathMessage
 
                                 $expandedItems.Value += $currentArchiveEntryPath
                             }
                         }
-                    }
-                    else
-                    {
-                        try
-                        {
+                    } else {
+                        try {
                             $currentArchiveEntryFileInfo = New-Object -TypeName System.IO.FileInfo -ArgumentList $currentArchiveEntryPath
                             $parentDirExists = Test-Path -LiteralPath $currentArchiveEntryFileInfo.DirectoryName -PathType Container
 
                             # If the Parent directory of the current entry in the archive file does not exist, then create it.
-                            if ($parentDirExists -eq $false)
-                            {
+                            if ($parentDirExists -eq $false) {
                                 New-Item $currentArchiveEntryFileInfo.DirectoryName -ItemType Directory -Confirm:$isConfirm | Out-Null
 
-                                if (!(Test-Path -LiteralPath $currentArchiveEntryFileInfo.DirectoryName -PathType Container))
-                                {
+                                if (!(Test-Path -LiteralPath $currentArchiveEntryFileInfo.DirectoryName -PathType Container)) {
                                     # The directory referred by $currentArchiveEntryFileInfo.DirectoryName was not successfully created.
                                     # This could be because the user has specified -Confirm paramter when Expand-Archive was invoked
                                     # and authorization was not provided when confirmation was prompted. In such a scenario,
@@ -1997,27 +1751,21 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
                             # Check if the file in to which the current archive entry contents
                             # would be expanded already exists.
-                            if ($currentArchiveEntryFileInfo.Exists)
-                            {
-                                if ($force)
-                                {
+                            if ($currentArchiveEntryFileInfo.Exists) {
+                                if ($force) {
                                     Remove-Item -LiteralPath $currentArchiveEntryFileInfo.FullName -Force -ErrorVariable ev -Verbose:$isVerbose -Confirm:$isConfirm
-                                    if ($ev -ne $null)
-                                    {
+                                    if ($ev -ne $null) {
                                         $hasNonTerminatingError = $true
                                     }
 
-                                    if (Test-Path -LiteralPath $currentArchiveEntryFileInfo.FullName -PathType Leaf)
-                                    {
+                                    if (Test-Path -LiteralPath $currentArchiveEntryFileInfo.FullName -PathType Leaf) {
                                         # The file referred by $currentArchiveEntryFileInfo.FullName was not successfully removed.
                                         # This could be because the user has specified -Confirm paramter when Expand-Archive was invoked
                                         # and authorization was not provided when confirmation was prompted. In such a scenario,
                                         # we skip the current file in the archive and continue with the remaining archive file contents.
                                         Continue
                                     }
-                                }
-                                else
-                                {
+                                } else {
                                     # Write non-terminating error to the pipeline.
                                     $errorMessage = ($LocalizedData.FileExistsError -f $currentArchiveEntryFileInfo.FullName, $archiveFile, $currentArchiveEntryFileInfo.FullName, $currentArchiveEntryFileInfo.FullName)
                                     $errorRecord = CreateErrorRecordHelper "ExpandArchiveFileExists" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidOperation) $null $currentArchiveEntryFileInfo.FullName
@@ -2026,8 +1774,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                                 }
                             }
 
-                            if (!$hasNonTerminatingError)
-                            {
+                            if (!$hasNonTerminatingError) {
                                 [System.IO.Compression.ZipFileExtensions]::ExtractToFile($currentArchiveEntry, $currentArchiveEntryPath, $false)
 
                                 # Add the expanded file path to the $expandedItems array,
@@ -2039,16 +1786,12 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                                 $addFiletoExpandedPathMessage = ($LocalizedData.CreateFileAtExpandedPath -f $currentArchiveEntryPath)
                                 Write-Verbose $addFiletoExpandedPathMessage
                             }
-                        }
-                        finally
-                        {
-                            If ($null -ne $destStream)
-                            {
+                        } finally {
+                            If ($null -ne $destStream) {
                                 $destStream.Dispose()
                             }
 
-                            If ($null -ne $srcStream)
-                            {
+                            If ($null -ne $srcStream) {
                                 $srcStream.Dispose()
                             }
                         }
@@ -2061,16 +1804,12 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                     $currentSegmentWeight = 100
                     ProgressBarHelper "Expand-Archive" $progressBarStatus $previousSegmentWeight $currentSegmentWeight $zipArchive.Entries.Count  $currentEntryCount
                 }
-            }
-            finally
-            {
-                If ($null -ne $zipArchive)
-                {
+            } finally {
+                If ($null -ne $zipArchive) {
                     $zipArchive.Dispose()
                 }
 
-                If ($null -ne $archiveFileStream)
-                {
+                If ($null -ne $archiveFileStream) {
                     $archiveFileStream.Dispose()
                 }
 
@@ -2079,13 +1818,12 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             }
         }
 
-<############################################################################################
+        <############################################################################################
 # ProgressBarHelper: This is a helper function used to display progress message.
 # This function is used by both Compress-Archive & Expand-Archive to display archive file
 # creation/expansion progress.
 ############################################################################################>
-        function ProgressBarHelper
-        {
+        function ProgressBarHelper {
             param
             (
                 [string]
@@ -2110,22 +1848,20 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             if ($currentEntryCount -gt 0 -and
                 $totalNumberofEntries -gt 0 -and
                 $previousSegmentWeight -ge 0 -and
-                $currentSegmentWeight -gt 0)
-            {
-                $entryDefaultWeight = $currentSegmentWeight/[double]$totalNumberofEntries
+                $currentSegmentWeight -gt 0) {
+                $entryDefaultWeight = $currentSegmentWeight / [double]$totalNumberofEntries
 
                 $percentComplete = $previousSegmentWeight + ($entryDefaultWeight * $currentEntryCount)
                 Write-Progress -Activity $cmdletName -Status $status -PercentComplete $percentComplete
             }
         }
 
-<############################################################################################
+        <############################################################################################
 # CSVHelper: This is a helper function used to append comma after each path specifid by
 # the SourcePath array. This helper function is used to display all the user supplied paths
 # in the WhatIf message.
 ############################################################################################>
-        function CSVHelper
-        {
+        function CSVHelper {
             param
             (
                 [string[]]
@@ -2133,34 +1869,26 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             )
 
             # SourcePath has already been validated by the calling funcation.
-            if ($sourcePath.Count -gt 1)
-            {
+            if ($sourcePath.Count -gt 1) {
                 $sourcePathInCsvFormat = "`n"
-                for ($currentIndex = 0; $currentIndex -lt $sourcePath.Count; $currentIndex++)
-                {
-                    if ($currentIndex -eq $sourcePath.Count - 1)
-                    {
+                for ($currentIndex = 0; $currentIndex -lt $sourcePath.Count; $currentIndex++) {
+                    if ($currentIndex -eq $sourcePath.Count - 1) {
                         $sourcePathInCsvFormat += $sourcePath[$currentIndex]
-                    }
-                    else
-                    {
+                    } else {
                         $sourcePathInCsvFormat += $sourcePath[$currentIndex] + "`n"
                     }
                 }
-            }
-            else
-            {
+            } else {
                 $sourcePathInCsvFormat = $sourcePath
             }
 
             return $sourcePathInCsvFormat
         }
 
-<############################################################################################
+        <############################################################################################
 # ThrowTerminatingErrorHelper: This is a helper function used to throw terminating error.
 ############################################################################################>
-        function ThrowTerminatingErrorHelper
-        {
+        function ThrowTerminatingErrorHelper {
             param
             (
                 [string]
@@ -2179,12 +1907,9 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $innerException
             )
 
-            if ($innerException -eq $null)
-            {
+            if ($innerException -eq $null) {
                 $exception = New-object System.IO.IOException $errorMessage
-            }
-            else
-            {
+            } else {
                 $exception = New-Object System.IO.IOException $errorMessage, $innerException
             }
 
@@ -2193,11 +1918,10 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             $PSCmdlet.ThrowTerminatingError($errorRecord)
         }
 
-<############################################################################################
+        <############################################################################################
 # CreateErrorRecordHelper: This is a helper function used to create an ErrorRecord
 ############################################################################################>
-        function CreateErrorRecordHelper
-        {
+        function CreateErrorRecordHelper {
             param
             (
                 [string]
@@ -2216,8 +1940,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 $targetObject
             )
 
-            if ($null -eq $exception)
-            {
+            if ($null -eq $exception) {
                 $exception = New-Object System.IO.IOException $errorMessage
             }
 
@@ -2230,19 +1953,14 @@ PreparingToExpandVerboseMessage=Preparing to expand...
         $isConfirm = $psboundparameters.ContainsKey("Confirm")
 
         $isDestinationPathProvided = $true
-        if ($DestinationPath -eq [string]::Empty)
-        {
+        if ($DestinationPath -eq [string]::Empty) {
             $resolvedDestinationPath = $pwd
             $isDestinationPathProvided = $false
-        }
-        else
-        {
+        } else {
             $destinationPathExists = Test-Path -Path $DestinationPath -PathType Container
-            if ($destinationPathExists)
-            {
+            if ($destinationPathExists) {
                 $resolvedDestinationPath = GetResolvedPathHelper $DestinationPath $false $PSCmdlet
-                if ($resolvedDestinationPath.Count -gt 1)
-                {
+                if ($resolvedDestinationPath.Count -gt 1) {
                     $errorMessage = ($LocalizedData.InvalidExpandedDirPathError -f $DestinationPath)
                     ThrowTerminatingErrorHelper "InvalidDestinationPath" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $DestinationPath
                 }
@@ -2250,17 +1968,13 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 # At this point we are sure that the provided path resolves to a valid single path.
                 # Calling Resolve-Path again to get the underlying provider name.
                 $suppliedDestinationPath = Resolve-Path -Path $DestinationPath
-                if ($suppliedDestinationPath.Provider.Name -ne "FileSystem")
-                {
+                if ($suppliedDestinationPath.Provider.Name -ne "FileSystem") {
                     $errorMessage = ($LocalizedData.ExpandArchiveInValidDestinationPath -f $DestinationPath)
                     ThrowTerminatingErrorHelper "InvalidDirectoryPath" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $DestinationPath
                 }
-            }
-            else
-            {
+            } else {
                 $createdItem = New-Item -Path $DestinationPath -ItemType Directory -Confirm:$isConfirm -Verbose:$isVerbose -ErrorAction Stop
-                if ($createdItem -ne $null -and $createdItem.PSProvider.Name -ne "FileSystem")
-                {
+                if ($createdItem -ne $null -and $createdItem.PSProvider.Name -ne "FileSystem") {
                     Remove-Item "$DestinationPath" -Force -Recurse -ErrorAction SilentlyContinue
                     $errorMessage = ($LocalizedData.ExpandArchiveInValidDestinationPath -f $DestinationPath)
                     ThrowTerminatingErrorHelper "InvalidDirectoryPath" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $DestinationPath
@@ -2271,8 +1985,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
         }
 
         $isWhatIf = $psboundparameters.ContainsKey("WhatIf")
-        if (!$isWhatIf)
-        {
+        if (!$isWhatIf) {
             $preparingToExpandVerboseMessage = ($LocalizedData.PreparingToExpandVerboseMessage)
             Write-Verbose $preparingToExpandVerboseMessage
 
@@ -2280,26 +1993,20 @@ PreparingToExpandVerboseMessage=Preparing to expand...
             ProgressBarHelper "Expand-Archive" $progressBarStatus 0 100 100 1
         }
     }
-    PROCESS
-    {
-        switch ($PsCmdlet.ParameterSetName)
-        {
-            "Path"
-            {
+    PROCESS {
+        switch ($PsCmdlet.ParameterSetName) {
+            "Path" {
                 $resolvedSourcePaths = GetResolvedPathHelper $Path $false $PSCmdlet
 
-                if ($resolvedSourcePaths.Count -gt 1)
-                {
+                if ($resolvedSourcePaths.Count -gt 1) {
                     $errorMessage = ($LocalizedData.InvalidArchiveFilePathError -f $Path, $PsCmdlet.ParameterSetName, $PsCmdlet.ParameterSetName)
                     ThrowTerminatingErrorHelper "InvalidArchiveFilePath" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $Path
                 }
             }
-            "LiteralPath"
-            {
+            "LiteralPath" {
                 $resolvedSourcePaths = GetResolvedPathHelper $LiteralPath $true $PSCmdlet
 
-                if ($resolvedSourcePaths.Count -gt 1)
-                {
+                if ($resolvedSourcePaths.Count -gt 1) {
                     $errorMessage = ($LocalizedData.InvalidArchiveFilePathError -f $LiteralPath, $PsCmdlet.ParameterSetName, $PsCmdlet.ParameterSetName)
                     ThrowTerminatingErrorHelper "InvalidArchiveFilePath" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $LiteralPath
                 }
@@ -2308,12 +2015,10 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 
         ValidateArchivePathHelper $resolvedSourcePaths
 
-        if ($pscmdlet.ShouldProcess($resolvedSourcePaths))
-        {
+        if ($pscmdlet.ShouldProcess($resolvedSourcePaths)) {
             $expandedItems = @()
 
-            try
-            {
+            try {
                 # StopProcessing is not avaliable in Script cmdlets. However the pipleline execution
                 # is terminated when ever 'CTRL + C' is entered by user to terminate the cmdlet execution.
                 # The finally block is executed whenever pipleline is terminated.
@@ -2325,14 +2030,12 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 # archive file contents would be expanded. If the path '$pwd\ArchiveFileName' already exists then we use the
                 # Windows default mechanism of appending a counter value at the end of the directory name where the contents
                 # would be expanded.
-                if (!$isDestinationPathProvided)
-                {
+                if (!$isDestinationPathProvided) {
                     $archiveFile = New-Object System.IO.FileInfo $resolvedSourcePaths
                     $resolvedDestinationPath = Join-Path -Path $resolvedDestinationPath -ChildPath $archiveFile.BaseName
                     $destinationPathExists = Test-Path -LiteralPath $resolvedDestinationPath -PathType Container
 
-                    if (!$destinationPathExists)
-                    {
+                    if (!$destinationPathExists) {
                         New-Item -Path $resolvedDestinationPath -ItemType Directory -Confirm:$isConfirm -Verbose:$isVerbose -ErrorAction Stop | Out-Null
                     }
                 }
@@ -2340,15 +2043,11 @@ PreparingToExpandVerboseMessage=Preparing to expand...
                 ExpandArchiveHelper $resolvedSourcePaths $resolvedDestinationPath ([ref]$expandedItems) $Force $isVerbose $isConfirm
 
                 $isArchiveFileProcessingComplete = $true
-            }
-            finally
-            {
+            } finally {
                 # The $isArchiveFileProcessingComplete would be set to $false if user has typed 'CTRL + C' to
                 # terminate the cmdlet execution or if an unhandled exception is thrown.
-                if ($isArchiveFileProcessingComplete -eq $false)
-                {
-                    if ($expandedItems.Count -gt 0)
-                    {
+                if ($isArchiveFileProcessingComplete -eq $false) {
+                    if ($expandedItems.Count -gt 0) {
                         # delete the expanded file/directory as the archive
                         # file was not completly expanded.
                         $expandedItems | ForEach-Object { Remove-Item $_ -Force -Recurse }
@@ -2359,8 +2058,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
     }
 }
 
-function Write-LocalMessage
-{
+function Write-LocalMessage {
     [CmdletBinding()]
     Param (
         [string]$Message
@@ -2371,8 +2069,7 @@ function Write-LocalMessage
 }
 #endregion Utility Functions
 
-try
-{
+try {
     [System.Net.ServicePointManager]::SecurityProtocol = "Tls12"
 
     Write-LocalMessage -Message "Downloading repository from '$($BaseUrl)/archive/$($Branch).zip'"
@@ -2398,8 +2095,7 @@ try
     if ($doUserMode) { $path = "$(Split-Path $profile.CurrentUserAllHosts)\Modules\$($ModuleName)" }
     if ($PSVersionTable.PSVersion.Major -ge 5) { $path += "\$moduleVersion" }
 
-    if ((Test-Path $path) -and (-not $Force))
-    {
+    if ((Test-Path $path) -and (-not $Force)) {
         Write-LocalMessage -Message "Module already installed, interrupting installation"
         return
     }
@@ -2408,8 +2104,7 @@ try
     $null = New-Item -Path $path -ItemType Directory -Force -ErrorAction Stop
 
     Write-LocalMessage -Message "Copying files to $($path)"
-    foreach ($file in (Get-ChildItem -Path $basePath))
-    {
+    foreach ($file in (Get-ChildItem -Path $basePath)) {
         Move-Item -Path $file.FullName -Destination $path -ErrorAction Stop
     }
 
@@ -2418,9 +2113,7 @@ try
     Remove-Item -Path "$($env:TEMP)\$($ModuleName).zip" -Force
 
     Write-LocalMessage -Message "Installation of the module $($ModuleName), Branch $($Branch), Version $($moduleVersion) completed successfully!"
-}
-catch
-{
+} catch {
     Write-LocalMessage -Message "Installation of the module $($ModuleName) failed!"
 
     Write-LocalMessage -Message "Cleaning up temporary files"


### PR DESCRIPTION
# 1.5.1.1
- Info: No new functions
- Fix: fixing some typos
- Upd: some more code refactoring
 
# 1.5.1.0
- Upd: Refactoring module
    - Refactoring directory and file structure, to meet my current standard
    - Start to implement PSFramework module for logging purpose and maybe more
- Upd: Change variable scopes from "global" to "script"
    - PRTGServer, PRTGUser, PRTGPass, PRTGSensorTree
- Upd: Command Connect-PRTGServer
    - Implement new switch "DoNotQuerySensorTree" (alias 'QuickConnect', 'NoSensorTree') to allow faster connection to PRTG Server when only live queries are needed to do.
- Fix: Issue #1 - Set-PRTGObjectAlamAcknowledgement is misspellt
    - Rename command to "Set-PRTGObjectAlarmAcknowledgement" and set an alias for the wrong name to avoid bracking change